### PR TITLE
Renaming "View"

### DIFF
--- a/env/env_test.go
+++ b/env/env_test.go
@@ -135,12 +135,12 @@ func TestEnv(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			os.Setenv(testCase.EnvVarName, testCase.EnvVarValue)
 			defer os.Unsetenv(testCase.EnvVarName)
-			view, err := dials.Config(context.Background(), testCase.ConfigStruct, &testCase.Source)
+			d, err := dials.Config(context.Background(), testCase.ConfigStruct, &testCase.Source)
 			if testCase.ExpectedErr != "" {
 				require.Contains(t, err.Error(), testCase.ExpectedErr)
 			} else {
 				require.NoError(t, err)
-				assert.EqualValues(t, testCase.Expected, view.Get())
+				assert.EqualValues(t, testCase.Expected, d.View())
 			}
 		})
 	}

--- a/flag/flag_test.go
+++ b/flag/flag_test.go
@@ -27,14 +27,14 @@ func TestDirectBasic(t *testing.T) {
 	buf := &bytes.Buffer{}
 	src.Flags.SetOutput(buf)
 
-	v, err := dials.Config(ctx, &Config{}, src)
+	d, err := dials.Config(ctx, &Config{}, src)
 	if err != nil {
 		t.Fatal(err)
 	}
 	src.Flags.Usage()
 	t.Log(buf.String())
 
-	got, ok := v.Get().(*Config)
+	got, ok := d.View().(*Config)
 	if !ok {
 		t.Fatalf("want: *Config, got: %T", got)
 	}
@@ -270,14 +270,14 @@ func TestTable(t *testing.T) {
 			s, setupErr := NewSetWithArgs(DashesNameConfig(), tbl.tmpl, tbl.args)
 			require.NoError(t, setupErr, "failed to setup Set")
 
-			v, cfgErr := dials.Config(ctx, tbl.tmpl, s)
+			d, cfgErr := dials.Config(ctx, tbl.tmpl, s)
 			if tbl.expErr != "" {
 				require.EqualError(t, cfgErr, tbl.expErr)
 				return
 			}
 			require.NoError(t, cfgErr, "failed to stack/Value()")
 
-			assert.EqualValues(t, tbl.expected, v.Get())
+			assert.EqualValues(t, tbl.expected, d.View())
 		})
 	}
 }

--- a/integrationtests/case_conversion_transformer_test.go
+++ b/integrationtests/case_conversion_transformer_test.go
@@ -66,14 +66,14 @@ func TestReformatDialsTags(t *testing.T) {
 			t.Parallel()
 
 			myConfig := &testConfig{}
-			view, err := dials.Config(
+			d, err := dials.Config(
 				context.Background(),
 				myConfig,
 				tagformat.ReformatDialsTagSource(&static.StringSource{Data: tc.data, Decoder: tc.decoder}, caseconversion.DecodeLowerSnakeCase, caseconversion.EncodeLowerCamelCase),
 			)
 			require.NoError(t, err)
 
-			c, ok := view.Get().(*testConfig)
+			c, ok := d.View().(*testConfig)
 			assert.True(t, ok)
 			assert.Equal(t, "something", c.DatabaseName)
 			assert.Equal(t, "127.0.0.1", c.DatabaseAddress)
@@ -165,14 +165,14 @@ func TestReformatDialsTagsInNestedStruct(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			t.Parallel()
 			myConfig := &testConfig{}
-			view, err := dials.Config(
+			d, err := dials.Config(
 				context.Background(),
 				myConfig,
 				tagformat.ReformatDialsTagSource(&static.StringSource{Data: tc.data, Decoder: tc.decoder}, caseconversion.DecodeLowerSnakeCase, caseconversion.EncodeLowerCamelCase),
 			)
 			require.NoError(t, err)
 
-			c, ok := view.Get().(*testConfig)
+			c, ok := d.View().(*testConfig)
 			assert.True(t, ok)
 			assert.Equal(t, "something", c.DatabaseName)
 			assert.Equal(t, "test", c.DatabaseUser.Username)

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -23,14 +23,14 @@ func TestJSON(t *testing.T) {
     }`
 
 	myConfig := &testConfig{}
-	view, err := dials.Config(
+	d, err := dials.Config(
 		context.Background(),
 		myConfig,
 		&static.StringSource{Data: jsonData, Decoder: &Decoder{}},
 	)
 	require.NoError(t, err)
 
-	c, ok := view.Get().(*testConfig)
+	c, ok := d.View().(*testConfig)
 	assert.True(t, ok)
 
 	assert.Equal(t, "something", c.Val1)
@@ -59,14 +59,14 @@ func TestShallowlyNestedJSON(t *testing.T) {
     }`
 
 	myConfig := &testConfig{}
-	view, err := dials.Config(
+	d, err := dials.Config(
 		context.Background(),
 		myConfig,
 		&static.StringSource{Data: jsonData, Decoder: &Decoder{}},
 	)
 	require.NoError(t, err)
 
-	c, ok := view.Get().(*testConfig)
+	c, ok := d.View().(*testConfig)
 	assert.True(t, ok)
 
 	assert.Equal(t, "something", c.DatabaseName)
@@ -103,14 +103,14 @@ func TestDeeplyNestedJSON(t *testing.T) {
 	}`
 
 	myConfig := &testConfig{}
-	view, err := dials.Config(
+	d, err := dials.Config(
 		context.Background(),
 		myConfig,
 		&static.StringSource{Data: jsonData, Decoder: &Decoder{}},
 	)
 	require.NoError(t, err)
 
-	c, ok := view.Get().(*testConfig)
+	c, ok := d.View().(*testConfig)
 	assert.True(t, ok)
 
 	assert.Equal(t, "something", c.DatabaseName)
@@ -153,14 +153,14 @@ func TestMoreDeeplyNestedJSON(t *testing.T) {
 	}`
 
 	myConfig := &testConfig{}
-	view, err := dials.Config(
+	d, err := dials.Config(
 		context.Background(),
 		myConfig,
 		&static.StringSource{Data: jsonData, Decoder: &Decoder{}},
 	)
 	require.NoError(t, err)
 
-	c, ok := view.Get().(*testConfig)
+	c, ok := d.View().(*testConfig)
 	assert.True(t, ok)
 
 	assert.Equal(t, "something", c.DatabaseName)

--- a/sourcewrap/blank_test.go
+++ b/sourcewrap/blank_test.go
@@ -89,11 +89,11 @@ func TestBlankSource(t *testing.T) {
 		B: 4809,
 		C: "fob",
 	}
-	v, err := dials.Config(ctx, &c, &b)
+	d, err := dials.Config(ctx, &c, &b)
 	if err != nil {
 		t.Fatalf("failed to construct View: %s", err)
 	}
-	initConf := v.Get().(*basicConf)
+	initConf := d.View().(*basicConf)
 	if *initConf != c {
 		t.Errorf("unexpected initial config: got %+v; expected %+v", *initConf, c)
 	}
@@ -106,7 +106,7 @@ func TestBlankSource(t *testing.T) {
 	}
 
 	// Await the new value, since it's sent asynchronously
-	newConfIface := <-v.Events()
+	newConfIface := <-d.Events()
 	newConf := newConfIface.(*basicConf)
 	if *newConf != c {
 		t.Errorf("unexpected new config: got %+v; expected %+v", *newConf, c)
@@ -131,11 +131,11 @@ func TestBlankSourceError(t *testing.T) {
 		B: 4809,
 		C: "fob",
 	}
-	v, err := dials.Config(ctx, &c, &b)
+	d, err := dials.Config(ctx, &c, &b)
 	if err != nil {
 		t.Fatalf("failed to construct View: %s", err)
 	}
-	initConf := v.Get().(*basicConf)
+	initConf := d.View().(*basicConf)
 	if *initConf != c {
 		t.Errorf("unexpected initial config: got %+v; expected %+v", *initConf, c)
 	}
@@ -159,7 +159,7 @@ func TestBlankSourceError(t *testing.T) {
 
 	// make sure nothing comes through on the events channel, sinc our
 	select {
-	case <-v.Events():
+	case <-d.Events():
 		t.Errorf("unexpected update to view with errored source")
 	default:
 	}
@@ -180,11 +180,11 @@ func TestBlankSourceWatcher(t *testing.T) {
 		B: 4809,
 		C: "fob",
 	}
-	v, err := dials.Config(ctx, &c, &b)
+	d, err := dials.Config(ctx, &c, &b)
 	if err != nil {
 		t.Fatalf("failed to construct View: %s", err)
 	}
-	initConf := v.Get().(*basicConf)
+	initConf := d.View().(*basicConf)
 	if *initConf != c {
 		t.Errorf("unexpected initial config: got %+v; expected %+v", *initConf, c)
 	}
@@ -198,7 +198,7 @@ func TestBlankSourceWatcher(t *testing.T) {
 
 	{
 		// Await the new value, since it's sent asynchronously
-		newConfIface := <-v.Events()
+		newConfIface := <-d.Events()
 		newConf := newConfIface.(*basicConf)
 		if *newConf != c {
 			t.Errorf("unexpected new config: got %+v; expected %+v", *newConf, c)
@@ -212,7 +212,7 @@ func TestBlankSourceWatcher(t *testing.T) {
 	triv.poke(ctx)
 	{
 		// Await the new value, since it's sent asynchronously
-		newConfIface := <-v.Events()
+		newConfIface := <-d.Events()
 		newConf := newConfIface.(*basicConf)
 		if *newConf != c {
 			t.Errorf("unexpected new config: got %+v; expected %+v", *newConf, c)
@@ -241,11 +241,11 @@ func TestBlankSourceErrorWatcher(t *testing.T) {
 		B: 4809,
 		C: "fob",
 	}
-	v, err := dials.Config(ctx, &c, &b)
+	d, err := dials.Config(ctx, &c, &b)
 	if err != nil {
 		t.Fatalf("failed to construct View: %s", err)
 	}
-	initConf := v.Get().(*basicConf)
+	initConf := d.View().(*basicConf)
 	if *initConf != c {
 		t.Errorf("unexpected initial config: got %+v; expected %+v", *initConf, c)
 	}
@@ -264,7 +264,7 @@ func TestBlankSourceErrorWatcher(t *testing.T) {
 
 	{
 		// Await the new value, since it's sent asynchronously
-		newConfIface := <-v.Events()
+		newConfIface := <-d.Events()
 		newConf := newConfIface.(*basicConf)
 		if *newConf != c {
 			t.Errorf("unexpected new config: got %+v; expected %+v", *newConf, c)

--- a/toml/toml_test.go
+++ b/toml/toml_test.go
@@ -23,14 +23,14 @@ func TestDecoder(t *testing.T) {
 `
 
 	myConfig := &testConfig{}
-	view, err := dials.Config(
+	d, err := dials.Config(
 		context.Background(),
 		myConfig,
 		&static.StringSource{Data: tomlData, Decoder: &Decoder{}},
 	)
 	require.NoError(t, err)
 
-	c, ok := view.Get().(*testConfig)
+	c, ok := d.View().(*testConfig)
 	require.True(t, ok)
 
 	assert.Equal(t, "something", c.Val1)
@@ -56,14 +56,14 @@ func TestShallowlyNestedTOML(t *testing.T) {
 `
 
 	myConfig := &testConfig{}
-	view, err := dials.Config(
+	d, err := dials.Config(
 		context.Background(),
 		myConfig,
 		&static.StringSource{Data: tomlData, Decoder: &Decoder{}},
 	)
 	require.NoError(t, err)
 
-	c, ok := view.Get().(*testConfig)
+	c, ok := d.View().(*testConfig)
 	assert.True(t, ok)
 
 	assert.Equal(t, "something", c.DatabaseName)
@@ -95,14 +95,14 @@ func TestDeeplyNestedTOML(t *testing.T) {
 	`
 
 	myConfig := &testConfig{}
-	view, err := dials.Config(
+	d, err := dials.Config(
 		context.Background(),
 		myConfig,
 		&static.StringSource{Data: tomlData, Decoder: &Decoder{}},
 	)
 	require.NoError(t, err)
 
-	c, ok := view.Get().(*testConfig)
+	c, ok := d.View().(*testConfig)
 	assert.True(t, ok)
 
 	assert.Equal(t, "something", c.DatabaseName)
@@ -137,14 +137,14 @@ func TestMoreDeeplyNestedTOML(t *testing.T) {
 	`
 
 	myConfig := &testConfig{}
-	view, err := dials.Config(
+	d, err := dials.Config(
 		context.Background(),
 		myConfig,
 		&static.StringSource{Data: tomlData, Decoder: &Decoder{}},
 	)
 	require.NoError(t, err)
 
-	c, ok := view.Get().(*testConfig)
+	c, ok := d.View().(*testConfig)
 	assert.True(t, ok)
 
 	assert.Equal(t, "something", c.DatabaseName)

--- a/yaml/yaml_test.go
+++ b/yaml/yaml_test.go
@@ -24,14 +24,14 @@ func TestYAML(t *testing.T) {
 `
 
 	myConfig := &testConfig{}
-	view, err := dials.Config(
+	d, err := dials.Config(
 		context.Background(),
 		myConfig,
 		&static.StringSource{Data: yamlData, Decoder: &Decoder{}},
 	)
 	require.NoError(t, err)
 
-	c, ok := view.Get().(*testConfig)
+	c, ok := d.View().(*testConfig)
 	require.True(t, ok)
 
 	assert.Equal(t, "something", c.Val1)
@@ -70,14 +70,14 @@ func TestShallowlyNestedYAML(t *testing.T) {
 	myConfig := &testConfig{}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	view, err := dials.Config(
+	d, err := dials.Config(
 		ctx,
 		myConfig,
 		&static.StringSource{Data: yamlData, Decoder: &Decoder{}},
 	)
 
 	require.NoError(t, err)
-	c, ok := view.Get().(*testConfig)
+	c, ok := d.View().(*testConfig)
 	assert.True(t, ok)
 
 	assert.Equal(t, "something", c.DatabaseName)
@@ -122,14 +122,14 @@ func TestMoreDeeplyNestedYAML(t *testing.T) {
 	}`
 
 	myConfig := &testConfig{}
-	view, err := dials.Config(
+	d, err := dials.Config(
 		context.Background(),
 		myConfig,
 		&static.StringSource{Data: yamlData, Decoder: &Decoder{}},
 	)
 	require.NoError(t, err)
 
-	c, ok := view.Get().(*testConfig)
+	c, ok := d.View().(*testConfig)
 	assert.True(t, ok)
 
 	assert.Equal(t, "something", c.DatabaseName)


### PR DESCRIPTION
Rather than having `View` be a type, make `Dials` the actual root type
and have `View` be a method that returns the current "view" of the
configuration.

This will be followed up with another PR that introduces `Fill` which
will take a pointer to a config structure to eliminate having to do the
type assert.