### PR TITLE
Fill

### DIFF
--- a/dials.go
+++ b/dials.go
@@ -106,6 +106,24 @@ func (d *Dials) Events() <-chan interface{} {
 	return d.updatesChan
 }
 
+// Fill populates the passed struct with the current value of the configuration.
+// It will panic if the type of `blankConfig` does not match the type of the
+// configuration value passed to `Config` in the first place.
+func (d *Dials) Fill(blankConfig interface{}) {
+	bVal := reflect.ValueOf(blankConfig)
+	currentVal := reflect.ValueOf(d.value.Load())
+
+	if bVal.Type() != currentVal.Type() {
+		panic(fmt.Sprintf(
+			"value to fill type (%s) does not match actual type (%s)",
+			bVal.Type(),
+			currentVal.Type(),
+		))
+	}
+
+	bVal.Elem().Set(currentVal.Elem())
+}
+
 func (d *Dials) monitor(
 	ctx context.Context,
 	t interface{},

--- a/dials_test.go
+++ b/dials_test.go
@@ -1,0 +1,27 @@
+package dials
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFill(t *testing.T) {
+	type testConfig struct {
+		Foo string
+	}
+
+	tc := testConfig{
+		Foo: "foo",
+	}
+
+	// no sources, just passing the defaults
+	d, err := Config(context.Background(), &tc)
+	require.NoError(t, err)
+
+	filledConfig := &testConfig{}
+	d.Fill(filledConfig)
+	assert.Equal(t, "foo", filledConfig.Foo)
+}


### PR DESCRIPTION
This introduces the `dials.Fill` method which allows you to populate a config struct without a type assert.