### PR TITLE
Handle Embedded fields at top level

### DIFF
--- a/transform/flatten_mangler.go
+++ b/transform/flatten_mangler.go
@@ -68,7 +68,11 @@ func (f *FlattenMangler) Mangle(sf reflect.StructField) ([]reflect.StructField, 
 		if t.Implements(textMReflectType) || reflect.PtrTo(t).Implements(textMReflectType) {
 			break
 		}
-		return f.flattenStruct([]string{sf.Name}, prefixTag, sf)
+		fieldPrefix := []string{}
+		if !sf.Anonymous {
+			fieldPrefix = append(fieldPrefix, sf.Name)
+		}
+		return f.flattenStruct(fieldPrefix, prefixTag, sf)
 	default:
 	}
 


### PR DESCRIPTION
Add a fix to handle embedded fields' names in flatten mangler at the top level and add a test for it. Before, it would add the name of the embedded field name to the nested fields in that structs and now that prevents the name addition if the field is anonymous. We handled it for embedded fields in nested structs, just not in the top level struct