### PR TITLE
Support Snake Case

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest]
-        goversion: [1.12, 1.13, 1.14]
+        goversion: [1.13, 1.14]
     steps:
       - name: Set up Go ${{matrix.goversion}} on ${{matrix.os}}
         uses: actions/setup-go@v1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vimeo/dials
 
-go 1.12
+go 1.13
 
 require (
 	github.com/fatih/structtag v1.2.0

--- a/tagformat/caseconversion/case_conversion_test.go
+++ b/tagformat/caseconversion/case_conversion_test.go
@@ -15,26 +15,36 @@ var decodeCases = []struct {
 }{
 	{"UpperCamelCase", []string{"upper", "camel", "case"}, DecodeUpperCamelCase, false},
 	{"lowerCamelCase", []string{"lower", "camel", "case"}, DecodeUpperCamelCase, true},
-	{"lowerCamelCase", []string{"lower", "camel", "case"}, DecodeLowerCamelCase, false},
 	{"UpperCamelCaseU", []string{"upper", "camel", "case", "u"}, DecodeUpperCamelCase, false},
-	{"lowerCamelCaseU", []string{"lower", "camel", "case", "u"}, DecodeLowerCamelCase, false},
-	{"lowerCamel0CaseU", []string{"lower", "camel0", "case", "u"}, DecodeLowerCamelCase, false},
-	{"NotLowerCamelCase", []string{}, DecodeLowerCamelCase, true},
-	{"1errorCase", []string{}, DecodeLowerCamelCase, true},
 	{"Case", []string{"case"}, DecodeUpperCamelCase, false},
 	{"UCCase", []string{"u", "c", "case"}, DecodeUpperCamelCase, false},
 	{"UC_Case", []string{}, DecodeUpperCamelCase, true},
 	{"Upper12CamelCase", []string{"upper12", "camel", "case"}, DecodeUpperCamelCase, false},
-	{"lower_snake_case", []string{"lower", "snake", "case"}, DecodeLowerSnakeCase, false},
+
+	{"lowerCamelCase", []string{"lower", "camel", "case"}, DecodeLowerCamelCase, false},
+	{"lowerCamelCaseU", []string{"lower", "camel", "case", "u"}, DecodeLowerCamelCase, false},
+	{"lowerCamel0CaseU", []string{"lower", "camel0", "case", "u"}, DecodeLowerCamelCase, false},
+	{"NotLowerCamelCase", []string{}, DecodeLowerCamelCase, true},
+	{"1errorCase", []string{}, DecodeLowerCamelCase, true},
+
 	{"kebab-case-string", []string{"kebab", "case", "string"}, DecodeKebabCase, false},
 	{"1kebab-case-string", []string{}, DecodeKebabCase, true},
 	{"kebab1-case-string", []string{"kebab1", "case", "string"}, DecodeKebabCase, false},
+	{"kebab1-case-string-", []string{"kebab1", "case", "string"}, DecodeKebabCase, false},
+	{"kebab-case-string-u", []string{"kebab", "case", "string", "u"}, DecodeKebabCase, false},
+
 	{"UPPER_SNAKE_CASE", []string{"upper", "snake", "case"}, DecodeUpperSnakeCase, false},
 	{"1UPPER_SNAKE_CASE", []string{}, DecodeUpperSnakeCase, true},
 	{"UPPER_SNAKE_CASE1", []string{"upper", "snake", "case1"}, DecodeUpperSnakeCase, false},
-	{"lower_snake_case_u", []string{"lower", "snake", "case", "u"}, DecodeLowerSnakeCase, false},
-	{"kebab-case-string-u", []string{"kebab", "case", "string", "u"}, DecodeKebabCase, false},
 	{"UPPER_SNAKE_CASE_U", []string{"upper", "snake", "case", "u"}, DecodeUpperSnakeCase, false},
+	{"UPPER_SNAKE_CASE_U_", []string{"upper", "snake", "case", "u"}, DecodeUpperSnakeCase, false},
+
+	{"lower_snake_case", []string{"lower", "snake", "case"}, DecodeLowerSnakeCase, false},
+	{"lower_snake_case_u", []string{"lower", "snake", "case", "u"}, DecodeLowerSnakeCase, false},
+	{"lower__snake_case", []string{"lower", "snake", "case"}, DecodeLowerSnakeCase, false},
+	{"_lower_snake_case", []string{"lower", "snake", "case"}, DecodeLowerSnakeCase, false},
+	{"lower_snake_case_", []string{"lower", "snake", "case"}, DecodeLowerSnakeCase, false},
+
 	{"jsonAPI", []string{"json", "api"}, DecodeGolangCamelCase, false},
 	{"JSONAPI", []string{"json", "api"}, DecodeGolangCamelCase, false},
 	{"TestJSONAPI", []string{"test", "json", "api"}, DecodeGolangCamelCase, false},
@@ -46,11 +56,9 @@ var decodeCases = []struct {
 	{"UpperCamelCaseXMLAPIDocs", []string{"upper", "camel", "case", "xml", "api", "docs"}, DecodeGolangCamelCase, false},
 	{"ABTest", []string{"ab", "test"}, DecodeGolangCamelCase, false},
 	{"jsonABTest", []string{"json", "ab", "test"}, DecodeGolangCamelCase, false},
+	{"decode_golangCamelCase_try", []string{"decode", "golang", "camel", "case", "try"}, DecodeGolangCamelCase, false},
+	{"decode_golangCamelCase_try_", []string{"decode", "golang", "camel", "case", "try"}, DecodeGolangCamelCase, false},
 	{"A", []string{"a"}, DecodeGolangCamelCase, false},
-
-	{"lower__snake_case", []string{"lower", "snake", "case"}, DecodeLowerSnakeCase, false},
-	{"_lower_snake_case", []string{"lower", "snake", "case"}, DecodeLowerSnakeCase, false},
-	{"lower_snake_case_", []string{"lower", "snake", "case", ""}, DecodeLowerSnakeCase, false},
 }
 
 func TestDecode(t *testing.T) {


### PR DESCRIPTION
1. Have DecodeGolangCamelCase support snake case since many instances of Go naming use snake case.
2. Ensure a trailing underscore in snake case decodes doesn't return an empty string in the decoded array
3. Group the decode functions together in the test
4. Remove support for go 1.12