### PR TITLE
Add dialsfieldpath tag in flatten mangler

### DIFF
--- a/transform/flatten_mangler.go
+++ b/transform/flatten_mangler.go
@@ -316,6 +316,7 @@ func GetField(v reflect.Value, t reflect.Type, fieldPath string) interface{} {
 		v = v.FieldByName(fname)
 	}
 
+	v = stripPtrs(v)
 	// if the final value isn't populated, return the zero value
 	if !v.IsValid() {
 		// ignore the kind and get the concrete type

--- a/transform/flatten_mangler.go
+++ b/transform/flatten_mangler.go
@@ -303,7 +303,7 @@ func stripPtrs(val reflect.Value) reflect.Value {
 
 // GetField should be called after calling the flatten mangler. It will look at
 // the dialsfieldpath tag of the mangled StructFields (sf) set by the flatten
-// mangler to get the path to the original field. It return the concrete value
+// mangler to get the path to the original field. It returns the concrete value
 // at the original field and if the original field value isn't populated, it will
 // return the zero value.
 func GetField(sf reflect.StructField, v reflect.Value) reflect.Value {

--- a/transform/flatten_mangler.go
+++ b/transform/flatten_mangler.go
@@ -117,7 +117,7 @@ func (f *FlattenMangler) flattenStruct(fieldPrefix, tagPrefix, fieldPath []strin
 			flattenedNames = append(fieldPrefix[:len(fieldPrefix):len(fieldPrefix)], nestedsf.Name)
 		}
 
-		// Need a separate flattenPath slice for the field path instead of just
+		// Need a separate flattenedPath slice for the field path instead of just
 		// using the fieldPrefix one because we need to add the names of the
 		// embedded fields to the slice so we can iterate through and get the original field
 		flattenedPath := append(fieldPath[:len(fieldPath):len(fieldPath)], nestedsf.Name)
@@ -301,11 +301,11 @@ func stripPtrs(val reflect.Value) reflect.Value {
 	return val
 }
 
-// GetField should be called after calling the flatten mangler. It will look at
+// GetField should be called after calling the flatten mangler. It uses
 // the dialsfieldpath tag of the mangled StructFields (sf) set by the flatten
 // mangler to get the path to the original field. It returns the concrete value
-// at the original field and if the original field value isn't populated, it will
-// return the zero value.
+// of the original field and if the original field value isn't populated or any
+// intermediate fields are nil, it will return the zero value for its concrete type.
 func GetField(sf reflect.StructField, v reflect.Value) reflect.Value {
 	fieldPath := sf.Tag.Get(dialsFieldPathTag)
 	// the tag should always be set after going through the flatten mangler

--- a/transform/flatten_mangler.go
+++ b/transform/flatten_mangler.go
@@ -316,7 +316,12 @@ func GetField(v reflect.Value, t reflect.Type, fieldPath string) interface{} {
 		v = v.FieldByName(fname)
 	}
 
-	v = stripPtrs(v)
+	// if the final value isn't populated, return the zero value
+	if !v.IsValid() {
+		// ignore the kind and get the concrete type
+		_, t = getUnderlyingKindType(t)
+		return reflect.Zero(t).Interface()
+	}
 
 	return v.Interface()
 }

--- a/transform/flatten_mangler.go
+++ b/transform/flatten_mangler.go
@@ -159,7 +159,7 @@ func (f *FlattenMangler) flattenStruct(fieldPrefix, tagPrefix, fieldPath []strin
 	return out, nil
 }
 
-// getTag uses the tag if one already exist or creates one based on the
+// getTag uses the tag if one already exists or creates one based on the
 // configured EncodingCasing function and fieldName. It returns the new parsed
 // StructTag, the updated slice of tags, and any error encountered
 func (f *FlattenMangler) getTag(sf *reflect.StructField, tags, flattenedPath []string) (reflect.StructTag, []string, error) {

--- a/transform/flatten_mangler_test.go
+++ b/transform/flatten_mangler_test.go
@@ -692,6 +692,16 @@ func TestGetField(t *testing.T) {
 			expected:  true,
 		},
 		{
+			name: "empty_pointerified fields",
+			testStruct: struct {
+				Hello   string
+				Goodbye *bool
+			}{},
+			fieldPath: "Goodbye",
+			fieldType: reflect.TypeOf(pbool),
+			expected:  false,
+		},
+		{
 			name: "nested_struct",
 			testStruct: struct {
 				Hello   string

--- a/transform/flatten_mangler_test.go
+++ b/transform/flatten_mangler_test.go
@@ -84,7 +84,7 @@ func TestFlattenMangler(t *testing.T) {
 			testStruct: 32,
 			modify: func(t testing.TB, val reflect.Value) {
 				assert.EqualValues(t, "ConfigField", val.Type().Field(0).Tag.Get(DialsTagName))
-				assert.EqualValues(t, "ConfigField", val.Type().Field(0).Tag.Get(DialsFieldPathTag))
+				assert.EqualValues(t, "ConfigField", val.Type().Field(0).Tag.Get(dialsFieldPathTag))
 				i := 32
 				val.Field(0).Set(reflect.ValueOf(&i))
 			},
@@ -97,7 +97,7 @@ func TestFlattenMangler(t *testing.T) {
 			testStruct: map[string]string{},
 			modify: func(t testing.TB, val reflect.Value) {
 				assert.EqualValues(t, "ConfigField", val.Type().Field(0).Tag.Get(DialsTagName))
-				assert.EqualValues(t, "ConfigField", val.Type().Field(0).Tag.Get(DialsFieldPathTag))
+				assert.EqualValues(t, "ConfigField", val.Type().Field(0).Tag.Get(dialsFieldPathTag))
 
 				m := map[string]string{
 					"hello":   "world",
@@ -119,7 +119,7 @@ func TestFlattenMangler(t *testing.T) {
 			modify: func(t testing.TB, val reflect.Value) {
 				assert.Equal(t, "ConfigField", val.Type().Field(0).Name)
 				assert.Equal(t, "ConfigField", val.Type().Field(0).Tag.Get(DialsTagName))
-				assert.Equal(t, "ConfigField", val.Type().Field(0).Tag.Get(DialsFieldPathTag))
+				assert.Equal(t, "ConfigField", val.Type().Field(0).Tag.Get(dialsFieldPathTag))
 				curTime, timeErr := time.Parse(time.Stamp, "May 18 15:04:05")
 				require.NoError(t, timeErr)
 				val.Field(0).Set(reflect.ValueOf(&curTime))
@@ -174,7 +174,7 @@ func TestFlattenMangler(t *testing.T) {
 
 				for i := 0; i < val.Type().NumField(); i++ {
 					assert.EqualValues(t, expectedDialsTags[i], val.Type().Field(i).Tag.Get(DialsTagName))
-					assert.EqualValues(t, expectedPathTags[i], val.Type().Field(i).Tag.Get(DialsFieldPathTag))
+					assert.EqualValues(t, expectedPathTags[i], val.Type().Field(i).Tag.Get(dialsFieldPathTag))
 				}
 
 				i := 42
@@ -223,7 +223,7 @@ func TestFlattenMangler(t *testing.T) {
 
 				for i := 0; i < val.Type().NumField(); i++ {
 					assert.EqualValues(t, expectedDialsTags[i], val.Type().Field(i).Tag.Get(DialsTagName))
-					assert.EqualValues(t, expectedFieldTags[i], val.Type().Field(i).Tag.Get(DialsFieldPathTag))
+					assert.EqualValues(t, expectedFieldTags[i], val.Type().Field(i).Tag.Get(dialsFieldPathTag))
 
 				}
 
@@ -300,7 +300,7 @@ func TestFlattenMangler(t *testing.T) {
 
 				for i := 0; i < len(expectedTags); i++ {
 					assert.EqualValues(t, expectedTags[i], val.Type().Field(i).Tag.Get(DialsTagName))
-					assert.EqualValues(t, expectedFieldPathTag[i], val.Type().Field(i).Tag.Get(DialsFieldPathTag))
+					assert.EqualValues(t, expectedFieldPathTag[i], val.Type().Field(i).Tag.Get(dialsFieldPathTag))
 
 				}
 
@@ -390,7 +390,7 @@ func TestFlattenMangler(t *testing.T) {
 				vtype := val.Type()
 				for i := 0; i < vtype.NumField(); i++ {
 					assert.EqualValues(t, expectedDialsTags[i], vtype.Field(i).Tag.Get(DialsTagName))
-					assert.EqualValues(t, expectedFieldTags[i], vtype.Field(i).Tag.Get(DialsFieldPathTag))
+					assert.EqualValues(t, expectedFieldTags[i], vtype.Field(i).Tag.Get(dialsFieldPathTag))
 					assert.EqualValues(t, expectedNames[i], vtype.Field(i).Name)
 				}
 
@@ -446,7 +446,7 @@ func TestFlattenMangler(t *testing.T) {
 				vtype := val.Type()
 				for i := 0; i < vtype.NumField(); i++ {
 					assert.EqualValues(t, expectedDialsTags[i], vtype.Field(i).Tag.Get(DialsTagName))
-					assert.EqualValues(t, expectedFieldTags[i], vtype.Field(i).Tag.Get(DialsFieldPathTag))
+					assert.EqualValues(t, expectedFieldTags[i], vtype.Field(i).Tag.Get(dialsFieldPathTag))
 					assert.EqualValues(t, expectedNames[i], vtype.Field(i).Name)
 				}
 
@@ -641,69 +641,66 @@ func TestTopLevelEmbed(t *testing.T) {
 	for i := 0; i < val.Type().NumField(); i++ {
 		assert.Equal(t, expectedNames[i], val.Type().Field(i).Name)
 		assert.EqualValues(t, expectedDialsTags[i], val.Type().Field(i).Tag.Get(DialsTagName))
-		assert.EqualValues(t, expectedFieldTags[i], val.Type().Field(i).Tag.Get(DialsFieldPathTag))
+		assert.EqualValues(t, expectedFieldTags[i], val.Type().Field(i).Tag.Get(dialsFieldPathTag))
 	}
-
-	assert.Equal(t, c.Embed.Foo, GetField(tVal, reflect.TypeOf("string"), "Embed,Foo"))
 }
 
 func TestGetField(t *testing.T) {
 	// used for pointers in tests
 	pbool := true
 	pint := 8
+	pstring := "creative word"
 
 	testcases := []struct {
 		name       string
 		testStruct interface{}
-		fieldType  reflect.Type
-		fieldPath  string
-		expected   interface{}
+		expected   []interface{}
 	}{
 		{
+			name: "zero-valued struct",
+			testStruct: &struct {
+				Hello   string
+				Goodbye bool
+			}{},
+			expected: []interface{}{"", false},
+		},
+		{
 			name: "simple_struct",
-			testStruct: struct {
+			testStruct: &struct {
 				Hello       string
 				littleHello string
 				Goodbye     bool
 			}{
-				Hello: "HeyJude",
+				Hello:   "HeyJude",
+				Goodbye: true,
 			},
-			fieldPath: "Hello",
-			expected:  "HeyJude",
-		},
-		{
-			name: "zero-valued struct",
-			testStruct: struct {
-				Hello   string
-				Goodbye bool
-			}{},
-			fieldPath: "Hello",
-			expected:  "",
+			// only two values in the array because the unexposed field
+			// won't be iterated in reflect.Type.NumField()
+			expected: []interface{}{"HeyJude", true},
 		},
 		{
 			name: "pointerified fields",
-			testStruct: struct {
-				Hello   string
+			testStruct: &struct {
+				Hello   *string
 				Goodbye *bool
 			}{
+				Hello:   &pstring,
 				Goodbye: &pbool,
 			},
-			fieldPath: "Goodbye",
-			expected:  true,
+			expected: []interface {
+			}{pstring, pbool},
 		},
 		{
 			name: "empty_pointerified fields",
-			testStruct: struct {
+			testStruct: &struct {
 				Hello   string
 				Goodbye *bool
 			}{},
-			fieldPath: "Goodbye",
-			fieldType: reflect.TypeOf(pbool),
-			expected:  false,
+			expected: []interface{}{"", false},
 		},
 		{
 			name: "nested_struct",
-			testStruct: struct {
+			testStruct: &struct {
 				Hello   string
 				Goodbye struct {
 					Here   bool
@@ -716,27 +713,24 @@ func TestGetField(t *testing.T) {
 					Comes  *int
 					TheSun string
 				}{
-					Comes: &pint,
+					Here:   true,
+					Comes:  &pint,
+					TheSun: "not the moon",
 				},
 			},
-			fieldPath: "Goodbye,Comes",
-			expected:  8,
+			expected: []interface{}{"", true, pint, "not the moon"},
 		},
 		{
 			name: "nested_empty_pointer_struct",
-			testStruct: struct {
+			testStruct: &struct {
 				Hello   string
 				Goodbye *struct {
 					Here   bool
 					Comes  *int
 					TheSun string
 				}
-			}{
-				Hello: "hello world",
-			},
-			fieldPath: "Goodbye,Comes",
-			fieldType: reflect.TypeOf(&pint),
-			expected:  0,
+			}{},
+			expected: []interface{}{"", false, 0, ""},
 		},
 		{
 			name: "nested_struct_with_embedded_fields",
@@ -748,27 +742,27 @@ func TestGetField(t *testing.T) {
 					Foo: "Foobars",
 				},
 			},
-			fieldPath: "Embed,Foo",
-			expected:  "Foobars",
-		},
-		{
-			name: "nested_struct_with_embedded_pointer_fields",
-			testStruct: &struct {
-				Hello string
-				*Embed
-			}{},
-			fieldPath: "Embed,Foo",
-			fieldType: reflect.TypeOf("string"),
-			expected:  "",
+			expected: []interface{}{"", "Foobars", false},
 		},
 	}
 	for _, testcase := range testcases {
 		tc := testcase
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			val := reflect.ValueOf(tc.testStruct)
-			i := GetField(val, tc.fieldType, tc.fieldPath)
-			assert.Equal(t, tc.expected, i)
+			cType := reflect.TypeOf(tc.testStruct)
+			cVal := reflect.ValueOf(tc.testStruct)
+
+			typeInstance := ptrify.Pointerify(cType.Elem(), cVal.Elem())
+
+			f := DefaultFlattenMangler()
+			tfmr := NewTransformer(typeInstance, f)
+			val, err := tfmr.Translate()
+			require.NoError(t, err)
+
+			for i := 0; i < val.Type().NumField(); i++ {
+				sf := val.Type().Field(i)
+				assert.EqualValues(t, tc.expected[i], GetField(sf, cVal).Interface())
+			}
 		})
 	}
 }


### PR DESCRIPTION
Add a tag to keep track of the path to the nested struct fields in the original struct. This will be used in the flags package so we can set the default value for the flags. The tag value will the comma separated string and we can convert the string to a slice of ints to get the value of the field by index (example in `TestTopLevelEmbed` test)