### PR TITLE
Parsestring renaming

### DIFF
--- a/flag/flaghelper/complex.go
+++ b/flag/flaghelper/complex.go
@@ -3,7 +3,7 @@ package flaghelper
 import (
 	"fmt"
 
-	"github.com/vimeo/dials/parsestring"
+	"github.com/vimeo/dials/parse"
 )
 
 // Complex128Var is a complex128 wrapper
@@ -18,7 +18,7 @@ func NewComplex128Var(c *complex128) *Complex128Var {
 
 // Set implement pflag.Value and flag.Value
 func (v *Complex128Var) Set(s string) error {
-	cmplx, err := parsestring.ParseComplex128(s)
+	cmplx, err := parse.ParseComplex128(s)
 	if err != nil {
 		return err
 
@@ -54,7 +54,7 @@ func NewComplex64Var(c *complex64) *Complex64Var {
 
 // Set implement pflag.Value and flag.Value
 func (v *Complex64Var) Set(s string) error {
-	cmplx, err := parsestring.ParseComplex64(s)
+	cmplx, err := parse.Complex64(s)
 	if err != nil {
 		return err
 

--- a/flag/flaghelper/complex.go
+++ b/flag/flaghelper/complex.go
@@ -18,7 +18,7 @@ func NewComplex128Var(c *complex128) *Complex128Var {
 
 // Set implement pflag.Value and flag.Value
 func (v *Complex128Var) Set(s string) error {
-	cmplx, err := parse.ParseComplex128(s)
+	cmplx, err := parse.Complex128(s)
 	if err != nil {
 		return err
 

--- a/flag/flaghelper/strings.go
+++ b/flag/flaghelper/strings.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/vimeo/dials/parsestring"
+	"github.com/vimeo/dials/parse"
 )
 
 // StringSliceFlag is a wrapper around a string slice
@@ -22,7 +22,7 @@ func NewStringSliceFlag(s *[]string) *StringSliceFlag {
 
 // Set implement pflag.Value and flag.Value
 func (v *StringSliceFlag) Set(s string) error {
-	parsed, err := parsestring.ParseStringSlice(s)
+	parsed, err := parse.ParseStringSlice(s)
 	if err != nil {
 		return err
 	}
@@ -65,7 +65,7 @@ func NewStringSetFlag(m *map[string]struct{}) *StringSetFlag {
 
 // Set implement pflag.Value and flag.Value
 func (v *StringSetFlag) Set(s string) error {
-	parsed, err := parsestring.ParseStringSet(s)
+	parsed, err := parse.ParseStringSet(s)
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,7 @@ func NewMapStringStringSliceFlag(m *map[string][]string) *MapStringStringSliceFl
 
 // Set implement pflag.Value and flag.Value
 func (v *MapStringStringSliceFlag) Set(s string) error {
-	parsed, err := parsestring.ParseStringStringSliceMap(s)
+	parsed, err := parse.ParseStringStringSliceMap(s)
 	if err != nil {
 		return err
 	}
@@ -181,7 +181,7 @@ func NewMapStringStringFlag(m *map[string]string) *MapStringStringFlag {
 
 // Set implement pflag.Value and flag.Value
 func (v *MapStringStringFlag) Set(s string) error {
-	parsed, err := parsestring.ParseMap(s, reflect.TypeOf(map[string]string{}))
+	parsed, err := parse.ParseMap(s, reflect.TypeOf(map[string]string{}))
 	if err != nil {
 		return err
 	}

--- a/flag/flaghelper/strings.go
+++ b/flag/flaghelper/strings.go
@@ -22,7 +22,7 @@ func NewStringSliceFlag(s *[]string) *StringSliceFlag {
 
 // Set implement pflag.Value and flag.Value
 func (v *StringSliceFlag) Set(s string) error {
-	parsed, err := parse.ParseStringSlice(s)
+	parsed, err := parse.StringSlice(s)
 	if err != nil {
 		return err
 	}
@@ -65,7 +65,7 @@ func NewStringSetFlag(m *map[string]struct{}) *StringSetFlag {
 
 // Set implement pflag.Value and flag.Value
 func (v *StringSetFlag) Set(s string) error {
-	parsed, err := parse.ParseStringSet(s)
+	parsed, err := parse.StringSet(s)
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,7 @@ func NewMapStringStringSliceFlag(m *map[string][]string) *MapStringStringSliceFl
 
 // Set implement pflag.Value and flag.Value
 func (v *MapStringStringSliceFlag) Set(s string) error {
-	parsed, err := parse.ParseStringStringSliceMap(s)
+	parsed, err := parse.StringStringSliceMap(s)
 	if err != nil {
 		return err
 	}
@@ -181,7 +181,7 @@ func NewMapStringStringFlag(m *map[string]string) *MapStringStringFlag {
 
 // Set implement pflag.Value and flag.Value
 func (v *MapStringStringFlag) Set(s string) error {
-	parsed, err := parse.ParseMap(s, reflect.TypeOf(map[string]string{}))
+	parsed, err := parse.Map(s, reflect.TypeOf(map[string]string{}))
 	if err != nil {
 		return err
 	}

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/heptio/velero v1.4.0 h1:I+EknMSKnAeY5pjIrAwv3YrwMfnSdVtVVxTjO8YwUjc=
 github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -8,7 +8,6 @@ github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/heptio/velero v1.4.0 h1:I+EknMSKnAeY5pjIrAwv3YrwMfnSdVtVVxTjO8YwUjc=
 github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/parse/complex.go
+++ b/parse/complex.go
@@ -1,4 +1,4 @@
-package parsestring
+package parse
 
 import (
 	"fmt"
@@ -6,8 +6,8 @@ import (
 	"strings"
 )
 
-// ParseComplex64 turns a string representation of a complex number into a complex64.
-func ParseComplex64(s string) (complex64, error) {
+// Complex64 turns a string representation of a complex number into a complex64.
+func Complex64(s string) (complex64, error) {
 	if plusCount := strings.Count(s, "+"); plusCount > 1 {
 		return 0, fmt.Errorf("too many '+'s: %d, at most 1 allowed",
 			plusCount)

--- a/parse/complex.go
+++ b/parse/complex.go
@@ -59,8 +59,8 @@ func parsePart64(part string) (float32, bool, error) {
 	return float32(val), isImag, nil
 }
 
-// ParseComplex128 turns a string representation of a complex number into a complex128.
-func ParseComplex128(s string) (complex128, error) {
+// Complex128 turns a string representation of a complex number into a complex128.
+func Complex128(s string) (complex128, error) {
 	if plusCount := strings.Count(s, "+"); plusCount > 1 {
 		return 0, fmt.Errorf("too many '+'s: %d, at most 1 allowed",
 			plusCount)

--- a/parse/complex_test.go
+++ b/parse/complex_test.go
@@ -1,4 +1,4 @@
-package parsestring
+package parse
 
 import (
 	"fmt"
@@ -59,7 +59,7 @@ func TestParseComplex128(t *testing.T) {
 
 }
 
-func TestParseComplex64(t *testing.T) {
+func TestComplex64(t *testing.T) {
 	for _, itbl := range []struct {
 		name        string
 		in          string
@@ -100,7 +100,7 @@ func TestParseComplex64(t *testing.T) {
 		tbl := itbl
 		t.Run(tbl.name, func(t *testing.T) {
 			t.Parallel()
-			num, err := ParseComplex64(tbl.in)
+			num, err := Complex64(tbl.in)
 			require.NoError(t, err)
 			assert.EqualValues(t, tbl.expected, num)
 			assert.EqualValues(t, tbl.expectedStr, fmt.Sprintf("%g", num))

--- a/parse/complex_test.go
+++ b/parse/complex_test.go
@@ -50,7 +50,7 @@ func TestParseComplex128(t *testing.T) {
 		t.Run(tbl.name, func(t *testing.T) {
 			t.Parallel()
 
-			num, err := ParseComplex128(tbl.in)
+			num, err := Complex128(tbl.in)
 			require.NoError(t, err)
 			assert.EqualValues(t, tbl.expected, num)
 			assert.EqualValues(t, tbl.expectedStr, fmt.Sprintf("%g", num))

--- a/parse/map.go
+++ b/parse/map.go
@@ -1,4 +1,4 @@
-package parsestring
+package parse
 
 import (
 	"fmt"

--- a/parse/map.go
+++ b/parse/map.go
@@ -5,16 +5,16 @@ import (
 	"reflect"
 )
 
-// ParseMap converts a string representation of a map with concrete values as
+// Map converts a string representation of a map with concrete values as
 // keys and vals into a reflect.Value representing that map.
-func ParseMap(s string, mapType reflect.Type) (reflect.Value, error) {
+func Map(s string, mapType reflect.Type) (reflect.Value, error) {
 	m := reflect.MakeMap(mapType)
 	keyType := mapType.Key()
 	valType := mapType.Elem()
 
 	splitErr := splitMap(s,
 		func(newKeyStr, newValStr string) error {
-			newKeyCast, err := ParseString(newKeyStr, keyType)
+			newKeyCast, err := String(newKeyStr, keyType)
 			if err != nil {
 				return fmt.Errorf("Error casting map key")
 			}
@@ -24,7 +24,7 @@ func ParseMap(s string, mapType reflect.Type) (reflect.Value, error) {
 				return fmt.Errorf("duplicate key %q, already has value %q", newKeyCast.Elem(), val)
 			}
 
-			newValCast, err := ParseString(newValStr, valType)
+			newValCast, err := String(newValStr, valType)
 			if err != nil {
 				return fmt.Errorf("Error casting map val")
 			}

--- a/parse/map_string_string_slice.go
+++ b/parse/map_string_string_slice.go
@@ -1,4 +1,4 @@
-package parsestring
+package parse
 
 // ParseStringStringSliceMap takes in a string representation of a map with
 // strings as keys and string slices as values, and converts it to a

--- a/parse/map_string_string_slice.go
+++ b/parse/map_string_string_slice.go
@@ -1,9 +1,9 @@
 package parse
 
-// ParseStringStringSliceMap takes in a string representation of a map with
+// StringStringSliceMap takes in a string representation of a map with
 // strings as keys and string slices as values, and converts it to a
 // map[string][]string.
-func ParseStringStringSliceMap(s string) (map[string][]string, error) {
+func StringStringSliceMap(s string) (map[string][]string, error) {
 	ss := map[string][]string{}
 	splitErr := splitMap(s,
 		func(k, v string) error {

--- a/parse/map_string_string_slice_test.go
+++ b/parse/map_string_string_slice_test.go
@@ -1,4 +1,4 @@
-package parsestring
+package parse
 
 import (
 	"fmt"

--- a/parse/map_string_string_slice_test.go
+++ b/parse/map_string_string_slice_test.go
@@ -69,7 +69,7 @@ func TestParseMapSlice(t *testing.T) {
 	} {
 		tbl := itbl
 		t.Run(tbl.name, func(t *testing.T) {
-			out, err := ParseStringStringSliceMap(tbl.input)
+			out, err := StringStringSliceMap(tbl.input)
 
 			if tbl.expectedErr != nil {
 				if err == nil {

--- a/parse/map_test.go
+++ b/parse/map_test.go
@@ -1,4 +1,4 @@
-package parsestring
+package parse
 
 import (
 	"fmt"

--- a/parse/map_test.go
+++ b/parse/map_test.go
@@ -84,7 +84,7 @@ func TestParseMapForStringStringMaps(t *testing.T) {
 	} {
 		tbl := itbl
 		t.Run(tbl.name, func(t *testing.T) {
-			ss, err := ParseMap(tbl.input, reflect.TypeOf(map[string]string{}))
+			ss, err := Map(tbl.input, reflect.TypeOf(map[string]string{}))
 			if tbl.expectedErr != nil {
 				assert.EqualError(t, err, tbl.expectedErr.Error())
 				return

--- a/parse/number.go
+++ b/parse/number.go
@@ -24,7 +24,7 @@ func parseNumber(strVal string, numberType reflect.Type) (reflect.Value, error) 
 
 		converted, err := strconv.ParseInt(strVal, 0, 64)
 		if err != nil {
-			return reflect.Value{}, &ParseNumberError{err: err}
+			return reflect.Value{}, &NumberError{err: err}
 		}
 
 		// Check for overflow
@@ -53,7 +53,7 @@ func parseNumber(strVal string, numberType reflect.Type) (reflect.Value, error) 
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		converted, err := strconv.ParseUint(strVal, 0, 64)
 		if err != nil {
-			return reflect.Value{}, &ParseNumberError{err: err}
+			return reflect.Value{}, &NumberError{err: err}
 		}
 
 		// Check for overflow
@@ -82,7 +82,7 @@ func parseNumber(strVal string, numberType reflect.Type) (reflect.Value, error) 
 	case reflect.Float32:
 		converted, err := strconv.ParseFloat(strVal, 32)
 		if err != nil {
-			return reflect.Value{}, &ParseNumberError{err: err}
+			return reflect.Value{}, &NumberError{err: err}
 		}
 
 		// Check for overflow
@@ -96,7 +96,7 @@ func parseNumber(strVal string, numberType reflect.Type) (reflect.Value, error) 
 	case reflect.Float64:
 		converted, err := strconv.ParseFloat(strVal, 64)
 		if err != nil {
-			return reflect.Value{}, &ParseNumberError{err: err}
+			return reflect.Value{}, &NumberError{err: err}
 		}
 
 		// Check for overflow
@@ -109,7 +109,7 @@ func parseNumber(strVal string, numberType reflect.Type) (reflect.Value, error) 
 	case reflect.Complex64:
 		converted, err := Complex64(strVal)
 		if err != nil {
-			return reflect.Value{}, &ParseNumberError{err: err}
+			return reflect.Value{}, &NumberError{err: err}
 		}
 
 		// Check for overflow
@@ -120,9 +120,9 @@ func parseNumber(strVal string, numberType reflect.Type) (reflect.Value, error) 
 
 		castVal = reflect.ValueOf(&converted)
 	case reflect.Complex128:
-		converted, err := ParseComplex128(strVal)
+		converted, err := Complex128(strVal)
 		if err != nil {
-			return reflect.Value{}, &ParseNumberError{err: err}
+			return reflect.Value{}, &NumberError{err: err}
 		}
 
 		// Check for overflow
@@ -149,15 +149,15 @@ func (e *OverflowError) Error() string {
 	return e.err.Error()
 }
 
-// ParseNumberError represents an error when parsing a string to generate a numeric type.
-type ParseNumberError struct {
+// NumberError represents an error when parsing a string to generate a numeric type.
+type NumberError struct {
 	err error
 }
 
-func (e *ParseNumberError) Error() string {
+func (e *NumberError) Error() string {
 	return e.err.Error()
 }
 
-func (e *ParseNumberError) Unwrap() error {
+func (e *NumberError) Unwrap() error {
 	return e.err
 }

--- a/parse/number.go
+++ b/parse/number.go
@@ -1,4 +1,4 @@
-package parsestring
+package parse
 
 import (
 	"fmt"
@@ -107,7 +107,7 @@ func parseNumber(strVal string, numberType reflect.Type) (reflect.Value, error) 
 
 		castVal = reflect.ValueOf(&converted)
 	case reflect.Complex64:
-		converted, err := ParseComplex64(strVal)
+		converted, err := Complex64(strVal)
 		if err != nil {
 			return reflect.Value{}, &ParseNumberError{err: err}
 		}

--- a/parse/parse_string.go
+++ b/parse/parse_string.go
@@ -1,4 +1,4 @@
-package parsestring
+package parse
 
 import (
 	"fmt"

--- a/parse/parse_string.go
+++ b/parse/parse_string.go
@@ -24,9 +24,9 @@ var (
 	complex128SliceType = reflect.TypeOf([]complex128{})
 )
 
-// ParseString casts the provided string into the provided type, returning the
+// String casts the provided string into the provided type, returning the
 // result in a reflect.Value.
-func ParseString(str string, t reflect.Type) (reflect.Value, error) {
+func String(str string, t reflect.Type) (reflect.Value, error) {
 	switch t.Kind() {
 	case reflect.String:
 		return reflect.ValueOf(&str), nil
@@ -42,7 +42,7 @@ func ParseString(str string, t reflect.Type) (reflect.Value, error) {
 		reflect.Complex64, reflect.Complex128:
 		return parseNumber(str, t)
 	case reflect.Slice:
-		converted, err := ParseStringSlice(str)
+		converted, err := StringSlice(str)
 		if err != nil {
 			return reflect.Value{}, err
 		}
@@ -52,7 +52,7 @@ func ParseString(str string, t reflect.Type) (reflect.Value, error) {
 		}
 		castSlice := reflect.MakeSlice(t, 0, len(converted))
 		for idx, strVal := range converted {
-			castVal, parseErr := ParseString(strVal, t.Elem())
+			castVal, parseErr := String(strVal, t.Elem())
 			if parseErr != nil {
 				return reflect.Value{}, fmt.Errorf("parse error of item %d %q: %s", idx, strVal, parseErr)
 			}
@@ -63,13 +63,13 @@ func ParseString(str string, t reflect.Type) (reflect.Value, error) {
 	case reflect.Map:
 		switch t {
 		case reflect.TypeOf(map[string][]string{}):
-			converted, err := ParseStringStringSliceMap(str)
+			converted, err := StringStringSliceMap(str)
 			if err != nil {
 				return reflect.Value{}, err
 			}
 			return reflect.ValueOf(converted), nil
 		case reflect.TypeOf(map[string]struct{}{}):
-			converted, err := ParseStringSet(str)
+			converted, err := StringSet(str)
 			if err != nil {
 				return reflect.Value{}, err
 			}
@@ -81,7 +81,7 @@ func ParseString(str string, t reflect.Type) (reflect.Value, error) {
 			if err != nil {
 				return reflect.Value{}, fmt.Errorf("Unsupported map type: %v", t)
 			}
-			converted, err := ParseMap(str, t)
+			converted, err := Map(str, t)
 			if err != nil {
 				return reflect.Value{}, err
 			}

--- a/parse/split_map.go
+++ b/parse/split_map.go
@@ -1,4 +1,4 @@
-package parsestring
+package parse
 
 import (
 	"fmt"
@@ -7,27 +7,27 @@ import (
 	"text/scanner"
 )
 
-// splitStringsSlice splits up a string composed of comma-separated values.
-// Destination type determined by func passed in.
-func splitStringsSlice(s string, addVal func(val string) error) error {
-	if len(s) == 0 {
-		return nil
-	}
+// splitMap splits the values that are csv key:value-pairs of strings in a
+// string into a map[string][]string.
+func splitMap(s string, addKV func(k, v string) error) error {
 	errs := map[scanner.Position]string{}
-
-	inValue := true
 
 	// initialize the scanner (note: sc.Init() blindly overwrites fields with sane-defaults)
 	sc := scanner.Scanner{}
 	sc.Init(strings.NewReader(s))
-	// We need a different default for Mode and Error, though
+	// We need different defaults for Mode and Error, though
 	sc.Mode = scanner.ScanStrings | scanner.ScanRawStrings |
 		scanner.ScanIdents | scanner.ScanInts |
 		scanner.ScanFloats | scanner.ScanChars
 	sc.Error = func(s *scanner.Scanner, msg string) {
 		errs[s.Pos()] = msg
 	}
-	for tok := sc.Scan(); tok != scanner.EOF && sc.ErrorCount == 0; tok = sc.Scan() {
+
+	inKey := true
+	inValue := false
+	curKey := ""
+	curVal := ""
+	for tok := sc.Scan(); sc.ErrorCount == 0; tok = sc.Scan() {
 		switch tok {
 		case scanner.String, scanner.RawString, scanner.Ident, scanner.Float, scanner.Int:
 			txt := sc.TokenText()
@@ -38,21 +38,41 @@ func splitStringsSlice(s string, addVal func(val string) error) error {
 				}
 				txt = parsedtxt
 			}
-			if inValue {
-				if addErr := addVal(txt); addErr != nil {
-					return fmt.Errorf("failed to add val %q: %s",
-						txt, addErr)
-				}
+
+			if inKey {
+				curKey = txt
+			} else if inValue && curKey != "" {
+				curVal = txt
 			} else {
 				return fmt.Errorf("unexpected string literal: %s",
 					sc.TokenText())
 			}
-			inValue = false
 		case ',':
+			if curKey != "" {
+				if addErr := addKV(curKey, curVal); addErr != nil {
+					return fmt.Errorf("map parsing failed on key %q: %s",
+						curKey, addErr)
+				}
+			}
+
+			curKey = ""
+			curVal = ""
+			inKey = true
+			inValue = false
+		case ':':
+			if inValue || curKey == "" {
+				return fmt.Errorf("unexpected colon")
+			}
+			inKey = false
 			inValue = true
-		default:
-			return fmt.Errorf("unexpected token %s with value: %q",
-				scanner.TokenString(tok), sc.TokenText())
+		case scanner.EOF:
+			if curKey != "" {
+				if addErr := addKV(curKey, curVal); addErr != nil {
+					return fmt.Errorf("map parsing failed on key %q: %s",
+						curKey, addErr)
+				}
+			}
+			return nil
 		}
 	}
 

--- a/parse/split_string_slice.go
+++ b/parse/split_string_slice.go
@@ -1,4 +1,4 @@
-package parsestring
+package parse
 
 import (
 	"fmt"
@@ -7,27 +7,27 @@ import (
 	"text/scanner"
 )
 
-// splitMap splits the values that are csv key:value-pairs of strings in a
-// string into a map[string][]string.
-func splitMap(s string, addKV func(k, v string) error) error {
+// splitStringsSlice splits up a string composed of comma-separated values.
+// Destination type determined by func passed in.
+func splitStringsSlice(s string, addVal func(val string) error) error {
+	if len(s) == 0 {
+		return nil
+	}
 	errs := map[scanner.Position]string{}
+
+	inValue := true
 
 	// initialize the scanner (note: sc.Init() blindly overwrites fields with sane-defaults)
 	sc := scanner.Scanner{}
 	sc.Init(strings.NewReader(s))
-	// We need different defaults for Mode and Error, though
+	// We need a different default for Mode and Error, though
 	sc.Mode = scanner.ScanStrings | scanner.ScanRawStrings |
 		scanner.ScanIdents | scanner.ScanInts |
 		scanner.ScanFloats | scanner.ScanChars
 	sc.Error = func(s *scanner.Scanner, msg string) {
 		errs[s.Pos()] = msg
 	}
-
-	inKey := true
-	inValue := false
-	curKey := ""
-	curVal := ""
-	for tok := sc.Scan(); sc.ErrorCount == 0; tok = sc.Scan() {
+	for tok := sc.Scan(); tok != scanner.EOF && sc.ErrorCount == 0; tok = sc.Scan() {
 		switch tok {
 		case scanner.String, scanner.RawString, scanner.Ident, scanner.Float, scanner.Int:
 			txt := sc.TokenText()
@@ -38,41 +38,21 @@ func splitMap(s string, addKV func(k, v string) error) error {
 				}
 				txt = parsedtxt
 			}
-
-			if inKey {
-				curKey = txt
-			} else if inValue && curKey != "" {
-				curVal = txt
+			if inValue {
+				if addErr := addVal(txt); addErr != nil {
+					return fmt.Errorf("failed to add val %q: %s",
+						txt, addErr)
+				}
 			} else {
 				return fmt.Errorf("unexpected string literal: %s",
 					sc.TokenText())
 			}
-		case ',':
-			if curKey != "" {
-				if addErr := addKV(curKey, curVal); addErr != nil {
-					return fmt.Errorf("map parsing failed on key %q: %s",
-						curKey, addErr)
-				}
-			}
-
-			curKey = ""
-			curVal = ""
-			inKey = true
 			inValue = false
-		case ':':
-			if inValue || curKey == "" {
-				return fmt.Errorf("unexpected colon")
-			}
-			inKey = false
+		case ',':
 			inValue = true
-		case scanner.EOF:
-			if curKey != "" {
-				if addErr := addKV(curKey, curVal); addErr != nil {
-					return fmt.Errorf("map parsing failed on key %q: %s",
-						curKey, addErr)
-				}
-			}
-			return nil
+		default:
+			return fmt.Errorf("unexpected token %s with value: %q",
+				scanner.TokenString(tok), sc.TokenText())
 		}
 	}
 

--- a/parse/string_set.go
+++ b/parse/string_set.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 )
 
-// StringSet splits a comma separated strings and constructs a
-// map[string]struc{} to represent a set
+// StringSet splits a comma separated string and constructs a
+// map[string]struct{} to represent a set
 func StringSet(s string) (map[string]struct{}, error) {
 	ss := map[string]struct{}{}
 

--- a/parse/string_set.go
+++ b/parse/string_set.go
@@ -1,4 +1,4 @@
-package parsestring
+package parse
 
 import (
 	"fmt"

--- a/parse/string_set.go
+++ b/parse/string_set.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 )
 
-func ParseStringSet(s string) (map[string]struct{}, error) {
+// StringSet splits a comma separated strings and constructs a
+// map[string]struc{} to represent a set
+func StringSet(s string) (map[string]struct{}, error) {
 	ss := map[string]struct{}{}
 
 	splitErr := splitStringsSlice(s, func(val string) error {

--- a/parse/string_set_test.go
+++ b/parse/string_set_test.go
@@ -1,4 +1,4 @@
-package parsestring
+package parse
 
 import (
 	"fmt"
@@ -8,82 +8,89 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseStringSlice(t *testing.T) {
+func TestParseStringSet(t *testing.T) {
+	sv := func(vs ...string) map[string]struct{} {
+		out := make(map[string]struct{}, len(vs))
+		for _, v := range vs {
+			out[v] = struct{}{}
+		}
+		return out
+	}
 	for _, itbl := range []struct {
 		name        string
 		input       string
-		expected    []string
+		expected    map[string]struct{}
 		expectedStr string
 		expectedErr error
 	}{
 		{
 			name:        "empty",
 			input:       "",
-			expected:    []string{},
+			expected:    sv(),
 			expectedStr: "",
 			expectedErr: nil,
 		},
 		{
 			name:        "one_ident",
 			input:       "a",
-			expected:    []string{"a"},
+			expected:    sv("a"),
 			expectedStr: "\"a\"",
 			expectedErr: nil,
 		},
 		{
 			name:        "two_idents",
 			input:       "a,b",
-			expected:    []string{"a", "b"},
+			expected:    sv("a", "b"),
 			expectedStr: "\"a\",\"b\"",
 			expectedErr: nil,
 		},
 		{
 			name:        "one_ident_one_int",
 			input:       "a,33",
-			expected:    []string{"a", "33"},
-			expectedStr: "\"a\",\"33\"",
+			expected:    sv("a", "33"),
+			expectedStr: "\"33\",\"a\"",
 			expectedErr: nil,
 		},
 		{
 			name:        "one_ident_one_float",
 			input:       "a,33.0",
-			expected:    []string{"a", "33.0"},
-			expectedStr: "\"a\",\"33.0\"",
+			expected:    sv("a", "33.0"),
+			expectedStr: `"33.0","a"`,
 			expectedErr: nil,
 		},
 		{
 			name:        "two_strings",
 			input:       `"a","b"`,
-			expected:    []string{"a", "b"},
+			expected:    sv("a", "b"),
 			expectedStr: `"a","b"`,
 			expectedErr: nil,
 		},
 		{
 			name:        "two_strings_with_comma",
 			input:       `"a","b,"`,
-			expected:    []string{"a", "b,"},
+			expected:    sv("a", "b,"),
 			expectedStr: `"a","b,"`,
 			expectedErr: nil,
 		},
 		{
 			name:        "two_strings_with_commas",
 			input:       `",a","b,"`,
-			expected:    []string{",a", "b,"},
+			expected:    sv(",a", "b,"),
 			expectedStr: `",a","b,"`,
 			expectedErr: nil,
 		},
 		{
 			name:        "two_strings_with_commas_and_escaped_quotes",
 			input:       "\",a\",\"b,\\\"\"",
-			expected:    []string{",a", "b,\""},
+			expected:    sv(",a", "b,\""),
 			expectedStr: `",a","b,\""`,
 			expectedErr: nil,
 		},
 		{
 			name:        "two_strings_with_commas_and_raw_quotes",
 			input:       "`a,`, `,b`",
-			expected:    []string{"a,", ",b"},
-			expectedStr: `"a,",",b"`,
+			expected:    sv("a,", ",b"),
+			expectedStr: `",b","a,"`,
 			expectedErr: nil,
 		},
 		{
@@ -94,11 +101,18 @@ func TestParseStringSlice(t *testing.T) {
 			expectedErr: fmt.Errorf(
 				"parsing failed: map[<input>:1:10:literal not terminated]"),
 		},
+		{
+			name:        "duplicate_value",
+			input:       "a,a,a",
+			expected:    nil,
+			expectedStr: "",
+			expectedErr: fmt.Errorf(
+				"failed to add val %q: %[1]q already present in set", "a"),
+		},
 	} {
 		tbl := itbl
 		t.Run(tbl.name, func(t *testing.T) {
-			out, err := ParseStringSlice(tbl.input)
-
+			out, err := ParseStringSet(tbl.input)
 			if tbl.expectedErr != nil {
 				assert.EqualError(t, err, tbl.expectedErr.Error())
 				return

--- a/parse/string_set_test.go
+++ b/parse/string_set_test.go
@@ -112,7 +112,7 @@ func TestParseStringSet(t *testing.T) {
 	} {
 		tbl := itbl
 		t.Run(tbl.name, func(t *testing.T) {
-			out, err := ParseStringSet(tbl.input)
+			out, err := StringSet(tbl.input)
 			if tbl.expectedErr != nil {
 				assert.EqualError(t, err, tbl.expectedErr.Error())
 				return

--- a/parse/string_slice.go
+++ b/parse/string_slice.go
@@ -1,4 +1,4 @@
-package parsestring
+package parse
 
 func ParseStringSlice(s string) ([]string, error) {
 	ss := []string{}

--- a/parse/string_slice.go
+++ b/parse/string_slice.go
@@ -1,6 +1,7 @@
 package parse
 
-func ParseStringSlice(s string) ([]string, error) {
+// StringSlice splits a comma separated string and constructs a slice
+func StringSlice(s string) ([]string, error) {
 	ss := []string{}
 
 	splitErr := splitStringsSlice(s, func(val string) error {

--- a/parse/string_slice_test.go
+++ b/parse/string_slice_test.go
@@ -97,7 +97,7 @@ func TestParseStringSlice(t *testing.T) {
 	} {
 		tbl := itbl
 		t.Run(tbl.name, func(t *testing.T) {
-			out, err := ParseStringSlice(tbl.input)
+			out, err := StringSlice(tbl.input)
 
 			if tbl.expectedErr != nil {
 				assert.EqualError(t, err, tbl.expectedErr.Error())

--- a/parse/string_slice_test.go
+++ b/parse/string_slice_test.go
@@ -1,4 +1,4 @@
-package parsestring
+package parse
 
 import (
 	"fmt"
@@ -8,89 +8,82 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseStringSet(t *testing.T) {
-	sv := func(vs ...string) map[string]struct{} {
-		out := make(map[string]struct{}, len(vs))
-		for _, v := range vs {
-			out[v] = struct{}{}
-		}
-		return out
-	}
+func TestParseStringSlice(t *testing.T) {
 	for _, itbl := range []struct {
 		name        string
 		input       string
-		expected    map[string]struct{}
+		expected    []string
 		expectedStr string
 		expectedErr error
 	}{
 		{
 			name:        "empty",
 			input:       "",
-			expected:    sv(),
+			expected:    []string{},
 			expectedStr: "",
 			expectedErr: nil,
 		},
 		{
 			name:        "one_ident",
 			input:       "a",
-			expected:    sv("a"),
+			expected:    []string{"a"},
 			expectedStr: "\"a\"",
 			expectedErr: nil,
 		},
 		{
 			name:        "two_idents",
 			input:       "a,b",
-			expected:    sv("a", "b"),
+			expected:    []string{"a", "b"},
 			expectedStr: "\"a\",\"b\"",
 			expectedErr: nil,
 		},
 		{
 			name:        "one_ident_one_int",
 			input:       "a,33",
-			expected:    sv("a", "33"),
-			expectedStr: "\"33\",\"a\"",
+			expected:    []string{"a", "33"},
+			expectedStr: "\"a\",\"33\"",
 			expectedErr: nil,
 		},
 		{
 			name:        "one_ident_one_float",
 			input:       "a,33.0",
-			expected:    sv("a", "33.0"),
-			expectedStr: `"33.0","a"`,
+			expected:    []string{"a", "33.0"},
+			expectedStr: "\"a\",\"33.0\"",
 			expectedErr: nil,
 		},
 		{
 			name:        "two_strings",
 			input:       `"a","b"`,
-			expected:    sv("a", "b"),
+			expected:    []string{"a", "b"},
 			expectedStr: `"a","b"`,
 			expectedErr: nil,
 		},
 		{
 			name:        "two_strings_with_comma",
 			input:       `"a","b,"`,
-			expected:    sv("a", "b,"),
+			expected:    []string{"a", "b,"},
 			expectedStr: `"a","b,"`,
 			expectedErr: nil,
 		},
 		{
 			name:        "two_strings_with_commas",
 			input:       `",a","b,"`,
-			expected:    sv(",a", "b,"),
+			expected:    []string{",a", "b,"},
 			expectedStr: `",a","b,"`,
 			expectedErr: nil,
 		},
 		{
 			name:        "two_strings_with_commas_and_escaped_quotes",
 			input:       "\",a\",\"b,\\\"\"",
-			expected:    sv(",a", "b,\""),
+			expected:    []string{",a", "b,\""},
 			expectedStr: `",a","b,\""`,
 			expectedErr: nil,
 		},
 		{
 			name:        "two_strings_with_commas_and_raw_quotes",
 			input:       "`a,`, `,b`",
-			expected:    sv("a,", ",b"),
-			expectedStr: `",b","a,"`,
+			expected:    []string{"a,", ",b"},
+			expectedStr: `"a,",",b"`,
 			expectedErr: nil,
 		},
 		{
@@ -101,18 +94,11 @@ func TestParseStringSet(t *testing.T) {
 			expectedErr: fmt.Errorf(
 				"parsing failed: map[<input>:1:10:literal not terminated]"),
 		},
-		{
-			name:        "duplicate_value",
-			input:       "a,a,a",
-			expected:    nil,
-			expectedStr: "",
-			expectedErr: fmt.Errorf(
-				"failed to add val %q: %[1]q already present in set", "a"),
-		},
 	} {
 		tbl := itbl
 		t.Run(tbl.name, func(t *testing.T) {
-			out, err := ParseStringSet(tbl.input)
+			out, err := ParseStringSlice(tbl.input)
+
 			if tbl.expectedErr != nil {
 				assert.EqualError(t, err, tbl.expectedErr.Error())
 				return

--- a/transform/string_casting_mangler.go
+++ b/transform/string_casting_mangler.go
@@ -49,7 +49,7 @@ func (*StringCastingMangler) Unmangle(sf reflect.StructField, vs []FieldValueTup
 		castTo = sf.Type.Elem()
 	}
 
-	return parse.ParseString(str, castTo)
+	return parse.String(str, castTo)
 }
 
 // ShouldRecurse always returns true in order to walk nested structs.

--- a/transform/string_casting_mangler.go
+++ b/transform/string_casting_mangler.go
@@ -3,7 +3,7 @@ package transform
 import (
 	"reflect"
 
-	"github.com/vimeo/dials/parsestring"
+	"github.com/vimeo/dials/parse"
 )
 
 var (
@@ -49,7 +49,7 @@ func (*StringCastingMangler) Unmangle(sf reflect.StructField, vs []FieldValueTup
 		castTo = sf.Type.Elem()
 	}
 
-	return parsestring.ParseString(str, castTo)
+	return parse.ParseString(str, castTo)
 }
 
 // ShouldRecurse always returns true in order to walk nested structs.

--- a/transform/string_casting_mangler_test.go
+++ b/transform/string_casting_mangler_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/vimeo/dials/parsestring"
+	"github.com/vimeo/dials/parse"
 	"github.com/vimeo/dials/ptrify"
 )
 
@@ -443,8 +443,8 @@ func TestParseOverflow(t *testing.T) {
 					t.Fatal()
 				}
 
-				_, isOverflowErr := unmangleErr.Unwrap().(*parsestring.OverflowError)
-				_, isParseNumberErr := unmangleErr.Unwrap().(*parsestring.ParseNumberError)
+				_, isOverflowErr := unmangleErr.Unwrap().(*parse.OverflowError)
+				_, isParseNumberErr := unmangleErr.Unwrap().(*parse.ParseNumberError)
 				if !assert.True(t, isOverflowErr || isParseNumberErr) {
 					t.Fatal()
 				}

--- a/transform/string_casting_mangler_test.go
+++ b/transform/string_casting_mangler_test.go
@@ -444,7 +444,7 @@ func TestParseOverflow(t *testing.T) {
 				}
 
 				_, isOverflowErr := unmangleErr.Unwrap().(*parse.OverflowError)
-				_, isParseNumberErr := unmangleErr.Unwrap().(*parse.ParseNumberError)
+				_, isParseNumberErr := unmangleErr.Unwrap().(*parse.NumberError)
 				if !assert.True(t, isOverflowErr || isParseNumberErr) {
 					t.Fatal()
 				}


### PR DESCRIPTION
Rename `parsestring` to `parse` and rename functions to remove the `Parse` prefix