### PR TITLE
Support hyphens

### DIFF
--- a/common/tags.go
+++ b/common/tags.go
@@ -1,0 +1,5 @@
+// Package common provides constants that are used among different dials sources
+package common
+
+// DialsTagName is the name of the dials tag.
+const DialsTagName = "dials"

--- a/env/env.go
+++ b/env/env.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	"github.com/vimeo/dials"
+	"github.com/vimeo/dials/common"
 	"github.com/vimeo/dials/tagformat"
 	"github.com/vimeo/dials/tagformat/caseconversion"
 	"github.com/vimeo/dials/transform"
@@ -28,11 +29,11 @@ type Source struct {
 // unchanged.)
 func (e *Source) Value(t *dials.Type) (reflect.Value, error) {
 	// flatten the nested fields
-	flattenMangler := transform.NewFlattenMangler(transform.DialsTagName, caseconversion.EncodeUpperCamelCase, caseconversion.EncodeUpperCamelCase)
+	flattenMangler := transform.NewFlattenMangler(common.DialsTagName, caseconversion.EncodeUpperCamelCase, caseconversion.EncodeUpperCamelCase)
 	// reformat the tags so they are SCREAMING_SNAKE_CASE
-	reformatTagMangler := tagformat.NewTagReformattingMangler(transform.DialsTagName, caseconversion.DecodeGoCamelCase, caseconversion.EncodeUpperSnakeCase)
+	reformatTagMangler := tagformat.NewTagReformattingMangler(common.DialsTagName, caseconversion.DecodeGoCamelCase, caseconversion.EncodeUpperSnakeCase)
 	// copy tags from "dials" to "dials_env" tag
-	tagCopyingMangler := &tagformat.TagCopyingMangler{SrcTag: transform.DialsTagName, NewTag: envTagName}
+	tagCopyingMangler := &tagformat.TagCopyingMangler{SrcTag: common.DialsTagName, NewTag: envTagName}
 	// convert all the fields in the flattened struct to string type so the environment variables can be set
 	stringCastingMangler := &transform.StringCastingMangler{}
 	tfmr := transform.NewTransformer(t.Type(), flattenMangler, reformatTagMangler, tagCopyingMangler, stringCastingMangler)

--- a/flag/flag.go
+++ b/flag/flag.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/vimeo/dials"
+	"github.com/vimeo/dials/common"
 	"github.com/vimeo/dials/flag/flaghelper"
 	"github.com/vimeo/dials/ptrify"
 	"github.com/vimeo/dials/tagformat/caseconversion"
@@ -152,7 +153,7 @@ func (s *Set) parse() error {
 }
 
 func (s *Set) registerFlags(tmpl reflect.Value, ptyp reflect.Type) error {
-	fm := transform.NewFlattenMangler(transform.DialsTagName, s.NameCfg.FieldNameEncodeCasing, s.NameCfg.TagEncodeCasing)
+	fm := transform.NewFlattenMangler(common.DialsTagName, s.NameCfg.FieldNameEncodeCasing, s.NameCfg.TagEncodeCasing)
 	tfmr := transform.NewTransformer(ptyp, fm)
 	val, TrnslErr := tfmr.Translate()
 	if TrnslErr != nil {
@@ -187,8 +188,9 @@ func (s *Set) registerFlags(tmpl reflect.Value, ptyp reflect.Type) error {
 			continue
 		}
 
-		// if the dialsflag tag has a hyphen (ex: `dialsflag:"-"`), don't
-		// register the flag
+		// If the field's dialsflag tag is a hyphen (ex: `dialsflag:"-"`),
+		// don't register the flag. Currently nested fields with "-" tag will
+		// still be registered
 		if dft, ok := sf.Tag.Lookup(dialsFlagTag); ok && (dft == "-") {
 			continue
 		}
@@ -445,7 +447,7 @@ func (s *Set) mkname(sf reflect.StructField) string {
 	}
 	// check if the dials tag is populated (it should be once it goes through
 	// the flatten mangler).
-	if name, ok := sf.Tag.Lookup(transform.DialsTagName); ok {
+	if name, ok := sf.Tag.Lookup(common.DialsTagName); ok {
 		return name
 	}
 

--- a/flag/flag.go
+++ b/flag/flag.go
@@ -187,6 +187,12 @@ func (s *Set) registerFlags(tmpl reflect.Value, ptyp reflect.Type) error {
 			continue
 		}
 
+		// if the dialsflag tag has a hyphen (ex: `dialsflag:"-"`), don't
+		// register the flag
+		if dft, ok := sf.Tag.Lookup(dialsFlagTag); ok && (dft == "-") {
+			continue
+		}
+
 		ft := sf.Type
 
 		k := ft.Kind()

--- a/flag/flag_test.go
+++ b/flag/flag_test.go
@@ -289,6 +289,23 @@ func TestTable(t *testing.T) {
 			}{F: struct{ A, B int }{A: 42, B: 34}, G: struct{ A int }{A: 5}},
 		},
 		{
+			name: "hierarchical_ints_multi_struct_with_hypen",
+			tmpl: &struct {
+				F struct{ A, B int }
+				G struct {
+					A int `dialsflag:"-"`
+				}
+			}{F: struct{ A, B int }{A: 4, B: 34}, G: struct {
+				A int `dialsflag:"-"`
+			}{A: 5234}},
+			args:   []string{"--f-a=42", "--g-a=5"},
+			expErr: "failed to parse: failed to parse flags: flag provided but not defined: -g-a",
+			expected: &struct {
+				F struct{ A, B int }
+				G struct{ A int }
+			}{F: struct{ A, B int }{A: 42, B: 34}, G: struct{ A int }{A: 5234}},
+		},
+		{
 			name: "hierarchical_ints_multi_struct_partially_defaulted _with_tags",
 			tmpl: &struct {
 				F struct {
@@ -329,7 +346,7 @@ func TestTable(t *testing.T) {
 	} {
 		tbl := itbl
 		t.Run(tbl.name, func(t *testing.T) {
-			t.Parallel()
+			// t.Parallel()
 			ctx := context.Background()
 			// use UpperSnakeCase instead of default (CamelCase) since
 			// single character field names like A and B make it hard to decode

--- a/flag/flag_test.go
+++ b/flag/flag_test.go
@@ -346,7 +346,7 @@ func TestTable(t *testing.T) {
 	} {
 		tbl := itbl
 		t.Run(tbl.name, func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 			ctx := context.Background()
 			// use UpperSnakeCase instead of default (CamelCase) since
 			// single character field names like A and B make it hard to decode

--- a/json/json.go
+++ b/json/json.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/vimeo/dials"
+	"github.com/vimeo/dials/common"
 	"github.com/vimeo/dials/tagformat"
 	"github.com/vimeo/dials/transform"
 )
@@ -30,7 +31,7 @@ func (d *Decoder) Decode(r io.Reader, t *dials.Type) (reflect.Value, error) {
 	// If there aren't any json tags, copy over from any dials tags.
 	tfmr := transform.NewTransformer(t.Type(),
 		&tagformat.TagCopyingMangler{
-			SrcTag: transform.DialsTagName, NewTag: JSONTagName})
+			SrcTag: common.DialsTagName, NewTag: JSONTagName})
 	val, tfmErr := tfmr.Translate()
 	if tfmErr != nil {
 		return reflect.Value{}, fmt.Errorf("failed to convert tags: %s", tfmErr)

--- a/overlay.go
+++ b/overlay.go
@@ -3,7 +3,6 @@ package dials
 import (
 	"errors"
 	"fmt"
-	"go/ast"
 	"reflect"
 
 	"github.com/vimeo/dials/ptrify"
@@ -115,9 +114,11 @@ func overlayStruct(base, overlay reflect.Value) error {
 	}
 	for i, j := 0, 0; i < base.NumField(); i++ {
 		currentField := base.Field(i)
-		if !ast.IsExported(base.Type().Field(i).Name) {
+
+		if ptrify.OmitField(base.Type().Field(i)) {
 			continue
 		}
+
 		switch currentField.Kind() {
 		// We skip channels and functions during
 		// pointerification, so we need to adjust indices

--- a/pflag/pflag.go
+++ b/pflag/pflag.go
@@ -198,6 +198,12 @@ func (s *Set) registerFlags(tmpl reflect.Value, ptyp reflect.Type) error {
 			continue
 		}
 
+		// if the dialspflag tag has a hyphen (ex: `dialspflag:"-"`), don't
+		// register the flag
+		if dpt, ok := sf.Tag.Lookup(dialsPFlagTag); ok && (dpt == "-") {
+			continue
+		}
+
 		ft := sf.Type
 
 		k := ft.Kind()

--- a/pflag/pflag.go
+++ b/pflag/pflag.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/vimeo/dials"
+	"github.com/vimeo/dials/common"
 	"github.com/vimeo/dials/flag/flaghelper"
 	"github.com/vimeo/dials/ptrify"
 	"github.com/vimeo/dials/tagformat/caseconversion"
@@ -163,7 +164,7 @@ func (s *Set) parse() error {
 }
 
 func (s *Set) registerFlags(tmpl reflect.Value, ptyp reflect.Type) error {
-	fm := transform.NewFlattenMangler(transform.DialsTagName, s.NameCfg.FieldNameEncodeCasing, s.NameCfg.TagEncodeCasing)
+	fm := transform.NewFlattenMangler(common.DialsTagName, s.NameCfg.FieldNameEncodeCasing, s.NameCfg.TagEncodeCasing)
 	tfmr := transform.NewTransformer(ptyp, fm)
 	val, TrnslErr := tfmr.Translate()
 	if TrnslErr != nil {
@@ -198,8 +199,9 @@ func (s *Set) registerFlags(tmpl reflect.Value, ptyp reflect.Type) error {
 			continue
 		}
 
-		// if the dialspflag tag has a hyphen (ex: `dialspflag:"-"`), don't
-		// register the flag
+		// If the field's dialspflag tag is a hyphen (ex: `dialspflag:"-"`),
+		// don't register the flag. Currently nested fields with "-" tag will
+		// still be registered
 		if dpt, ok := sf.Tag.Lookup(dialsPFlagTag); ok && (dpt == "-") {
 			continue
 		}
@@ -428,7 +430,7 @@ func (s *Set) mkname(sf reflect.StructField) string {
 	}
 	// check if the dials tag is populated (it should be once it goes through
 	// the flatten mangler).
-	if name, ok := sf.Tag.Lookup(transform.DialsTagName); ok {
+	if name, ok := sf.Tag.Lookup(common.DialsTagName); ok {
 		return name
 	}
 

--- a/pflag/pflag_test.go
+++ b/pflag/pflag_test.go
@@ -300,6 +300,23 @@ func TestPFlags(t *testing.T) {
 			}{F: struct{ A, B int }{A: 42, B: 34}, G: struct{ A int }{A: 5}},
 		},
 		{
+			name: "hierarchical_ints_multi_struct_with_hypen",
+			tmpl: &struct {
+				F struct{ A, B int }
+				G struct {
+					A int `dials:"-"`
+				}
+			}{F: struct{ A, B int }{A: 4, B: 34}, G: struct {
+				A int `dials:"-"`
+			}{A: 5234}},
+			args:   []string{"--f-a=42", "--g-a=5"},
+			expErr: "failed to parse pflags: unknown flag: --g-a",
+			expected: &struct {
+				F struct{ A, B int }
+				G struct{ A int }
+			}{F: struct{ A, B int }{A: 42, B: 34}, G: struct{ A int }{A: 5234}},
+		},
+		{
 			name: "hierarchical_ints_multi_struct_partially_defaulted _with_tags",
 			tmpl: &struct {
 				F struct {

--- a/ptrify/ptrify.go
+++ b/ptrify/ptrify.go
@@ -4,6 +4,8 @@ import (
 	"encoding"
 	"go/ast"
 	"reflect"
+
+	"github.com/vimeo/dials/transform"
 )
 
 // Note: this looks weird because it is, you need to call TypeOf on a nil
@@ -25,6 +27,10 @@ func Pointerify(original reflect.Type, tmpl reflect.Value) reflect.Type {
 		if !ast.IsExported(originalField.Name) {
 			// reflect.StructOf panics on unexported fields, skip
 			// them.
+			continue
+		}
+		if dtv, ok := originalField.Tag.Lookup(transform.DialsTagName); ok && dtv == "-" {
+			// ignore the fields with "-" tags (ex: `dials:"-"`)
 			continue
 		}
 		sf := pointerifyField(originalField, tmplFieldVal)

--- a/ptrify/ptrify.go
+++ b/ptrify/ptrify.go
@@ -5,7 +5,7 @@ import (
 	"go/ast"
 	"reflect"
 
-	"github.com/vimeo/dials/transform"
+	"github.com/vimeo/dials/common"
 )
 
 // Note: this looks weird because it is, you need to call TypeOf on a nil
@@ -29,7 +29,7 @@ func Pointerify(original reflect.Type, tmpl reflect.Value) reflect.Type {
 			// them.
 			continue
 		}
-		if dtv, ok := originalField.Tag.Lookup(transform.DialsTagName); ok && dtv == "-" {
+		if dtv, ok := originalField.Tag.Lookup(common.DialsTagName); ok && dtv == "-" {
 			// ignore the fields with "-" tags (ex: `dials:"-"`)
 			continue
 		}

--- a/ptrify/ptrify.go
+++ b/ptrify/ptrify.go
@@ -24,15 +24,11 @@ func Pointerify(original reflect.Type, tmpl reflect.Value) reflect.Type {
 		if tmpl.IsValid() {
 			tmplFieldVal = tmpl.Field(i)
 		}
-		if !ast.IsExported(originalField.Name) {
-			// reflect.StructOf panics on unexported fields, skip
-			// them.
+
+		if OmitField(originalField) {
 			continue
 		}
-		if dtv, ok := originalField.Tag.Lookup(common.DialsTagName); ok && dtv == "-" {
-			// ignore the fields with "-" tags (ex: `dials:"-"`)
-			continue
-		}
+
 		sf := pointerifyField(originalField, tmplFieldVal)
 		if sf != nil {
 			newFields = append(newFields, *sf)
@@ -40,6 +36,26 @@ func Pointerify(original reflect.Type, tmpl reflect.Value) reflect.Type {
 	}
 
 	return reflect.StructOf(newFields)
+}
+
+// OmitField returns a boolean indicating whether the field should be skipped
+// because the dials tag value is "-" (`dials:"-"`) or because the field is
+// unexported
+func OmitField(sf reflect.StructField) bool {
+
+	if !ast.IsExported(sf.Name) {
+		// reflect.StructOf panics on unexported fields, skip
+		// them.
+		return true
+	}
+
+	if dtv, ok := sf.Tag.Lookup(common.DialsTagName); ok && dtv == "-" {
+		// ignore the fields with "-" tags (ex: `dials:"-"`)
+		return true
+	}
+
+	return false
+
 }
 
 func pointerifyField(originalField reflect.StructField, tmplFieldVal reflect.Value) *reflect.StructField {

--- a/ptrify/ptrify_test.go
+++ b/ptrify/ptrify_test.go
@@ -153,6 +153,19 @@ func TestPointerify(t *testing.T) {
 				B *struct{ L *struct{ S *int32 } }
 			}{},
 		},
+		"three_deep_with_hypen": {
+			i: struct {
+				I struct {
+					J struct{ Q bool } `dials:"-"`
+					K int
+				}
+				B struct{ L *struct{ S int32 } }
+			}{},
+			expected: struct {
+				I *struct{ K *int }
+				B *struct{ L *struct{ S *int32 } }
+			}{},
+		},
 	} {
 		entry := inst
 		t.Run(name, func(t *testing.T) {

--- a/tagformat/expand_tags_test.go
+++ b/tagformat/expand_tags_test.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vimeo/dials/common"
 	"github.com/vimeo/dials/ptrify"
 	"github.com/vimeo/dials/transform"
 )
 
 func TestExpanddialsTag(t *testing.T) {
-	mangler := TagCopyingMangler{SrcTag: transform.DialsTagName, NewTag: "json"}
+	mangler := TagCopyingMangler{SrcTag: common.DialsTagName, NewTag: "json"}
 	sf := reflect.StructField{
 		Tag: `dials:"test"`,
 	}
@@ -31,7 +32,7 @@ func TestExpanddialsTags(t *testing.T) {
 	vc := reflect.ValueOf(tc)
 	cfg := ptrify.Pointerify(vc.Type(), vc)
 
-	mangler := TagCopyingMangler{SrcTag: transform.DialsTagName, NewTag: "yaml"}
+	mangler := TagCopyingMangler{SrcTag: common.DialsTagName, NewTag: "yaml"}
 	tfm := transform.NewTransformer(cfg, &mangler)
 
 	mangledVal, mangleErr := tfm.Translate()

--- a/tagformat/reformat_tags.go
+++ b/tagformat/reformat_tags.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fatih/structtag"
 	"github.com/vimeo/dials"
+	"github.com/vimeo/dials/common"
 	"github.com/vimeo/dials/sourcewrap"
 	"github.com/vimeo/dials/tagformat/caseconversion"
 	"github.com/vimeo/dials/transform"
@@ -79,7 +80,7 @@ func (k *TagReformattingMangler) ShouldRecurse(_ reflect.StructField) bool {
 // struct type passed in.
 func ReformatDialsTagSource(inner dials.Source, encodeFunc caseconversion.DecodeCasingFunc, decodeFunc caseconversion.EncodeCasingFunc) dials.Source {
 	return sourcewrap.NewTransformingSource(inner, &TagReformattingMangler{
-		tag:              transform.DialsTagName,
+		tag:              common.DialsTagName,
 		decodeCasingFunc: encodeFunc,
 		encodeCasingFunc: decodeFunc,
 	})

--- a/tagformat/reformat_tags_test.go
+++ b/tagformat/reformat_tags_test.go
@@ -4,10 +4,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/vimeo/dials/common"
 	"github.com/vimeo/dials/tagformat/caseconversion"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReformatdialsTag(t *testing.T) {

--- a/tagformat/reformat_tags_test.go
+++ b/tagformat/reformat_tags_test.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vimeo/dials/common"
 	"github.com/vimeo/dials/tagformat/caseconversion"
-	"github.com/vimeo/dials/transform"
 )
 
 func TestReformatdialsTag(t *testing.T) {
-	trm := NewTagReformattingMangler(transform.DialsTagName, caseconversion.DecodeLowerCamelCase, caseconversion.EncodeLowerSnakeCase)
+	trm := NewTagReformattingMangler(common.DialsTagName, caseconversion.DecodeLowerCamelCase, caseconversion.EncodeLowerSnakeCase)
 	sf := reflect.StructField{
 		Tag: `dials:"testTag"`,
 	}
@@ -22,7 +22,7 @@ func TestReformatdialsTag(t *testing.T) {
 }
 
 func TestNoTag(t *testing.T) {
-	trm := NewTagReformattingMangler(transform.DialsTagName, caseconversion.DecodeLowerCamelCase, caseconversion.EncodeLowerSnakeCase)
+	trm := NewTagReformattingMangler(common.DialsTagName, caseconversion.DecodeLowerCamelCase, caseconversion.EncodeLowerSnakeCase)
 	sf := reflect.StructField{}
 	newSFSlice, err := trm.Mangle(sf)
 	require.Len(t, newSFSlice, 1)

--- a/toml/toml.go
+++ b/toml/toml.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/vimeo/dials"
+	"github.com/vimeo/dials/common"
 	"github.com/vimeo/dials/tagformat"
 	"github.com/vimeo/dials/transform"
 
@@ -32,7 +33,7 @@ func (d *Decoder) Decode(r io.Reader, t *dials.Type) (reflect.Value, error) {
 	// tags aren't specified.
 	tfmr := transform.NewTransformer(t.Type(),
 		&tagformat.TagCopyingMangler{
-			SrcTag: transform.DialsTagName, NewTag: TOMLTagName})
+			SrcTag: common.DialsTagName, NewTag: TOMLTagName})
 	val, tfmErr := tfmr.Translate()
 	if tfmErr != nil {
 		return reflect.Value{}, fmt.Errorf("failed to convert tags: %s", tfmErr)

--- a/transform/flatten_mangler.go
+++ b/transform/flatten_mangler.go
@@ -7,13 +7,14 @@ import (
 	"strings"
 
 	"github.com/fatih/structtag"
+	"github.com/vimeo/dials/common"
 	"github.com/vimeo/dials/tagformat/caseconversion"
 )
 
 const (
-	// DialsTagName is the name of the dials tag.
-	DialsTagName = "dials"
-	// dialsFieldPathTag contains the path to the nested struct field as a
+	/* 	// DialsTagName is the name of the dials tag.
+	   	DialsTagName = "dials"
+	*/ // dialsFieldPathTag contains the path to the nested struct field as a
 	// comma separated string of the nested field index.
 	dialsFieldPathTag = "dialsfieldpath"
 )
@@ -32,7 +33,7 @@ type FlattenMangler struct {
 // nameEncodeCasing, and tagEncodeCasing
 func DefaultFlattenMangler() *FlattenMangler {
 	return &FlattenMangler{
-		tag:              DialsTagName,
+		tag:              common.DialsTagName,
 		nameEncodeCasing: caseconversion.EncodeUpperCamelCase,
 		tagEncodeCasing:  caseconversion.EncodeCasePreservingSnakeCase,
 	}

--- a/transform/flatten_mangler.go
+++ b/transform/flatten_mangler.go
@@ -12,9 +12,7 @@ import (
 )
 
 const (
-	/* 	// DialsTagName is the name of the dials tag.
-	   	DialsTagName = "dials"
-	*/ // dialsFieldPathTag contains the path to the nested struct field as a
+	// dialsFieldPathTag contains the path to the nested struct field as a
 	// comma separated string of the nested field index.
 	dialsFieldPathTag = "dialsfieldpath"
 )

--- a/transform/flatten_mangler_test.go
+++ b/transform/flatten_mangler_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vimeo/dials/common"
 	"github.com/vimeo/dials/ptrify"
 )
 
@@ -83,7 +84,7 @@ func TestFlattenMangler(t *testing.T) {
 			name:       "one member in struct of type int",
 			testStruct: 32,
 			modify: func(t testing.TB, val reflect.Value) {
-				assert.EqualValues(t, "config_field", val.Type().Field(0).Tag.Get(DialsTagName))
+				assert.EqualValues(t, "config_field", val.Type().Field(0).Tag.Get(common.DialsTagName))
 				assert.EqualValues(t, "ConfigField", val.Type().Field(0).Tag.Get(dialsFieldPathTag))
 				i := 32
 				val.Field(0).Set(reflect.ValueOf(&i))
@@ -96,7 +97,7 @@ func TestFlattenMangler(t *testing.T) {
 			name:       "one member in struct of type map",
 			testStruct: map[string]string{},
 			modify: func(t testing.TB, val reflect.Value) {
-				assert.EqualValues(t, "config_field", val.Type().Field(0).Tag.Get(DialsTagName))
+				assert.EqualValues(t, "config_field", val.Type().Field(0).Tag.Get(common.DialsTagName))
 				assert.EqualValues(t, "ConfigField", val.Type().Field(0).Tag.Get(dialsFieldPathTag))
 
 				m := map[string]string{
@@ -118,7 +119,7 @@ func TestFlattenMangler(t *testing.T) {
 			testStruct: time.Time{},
 			modify: func(t testing.TB, val reflect.Value) {
 				assert.Equal(t, "ConfigField", val.Type().Field(0).Name)
-				assert.Equal(t, "config_field", val.Type().Field(0).Tag.Get(DialsTagName))
+				assert.Equal(t, "config_field", val.Type().Field(0).Tag.Get(common.DialsTagName))
 				assert.Equal(t, "ConfigField", val.Type().Field(0).Tag.Get(dialsFieldPathTag))
 				curTime, timeErr := time.Parse(time.Stamp, "May 18 15:04:05")
 				require.NoError(t, timeErr)
@@ -173,7 +174,7 @@ func TestFlattenMangler(t *testing.T) {
 				}
 
 				for i := 0; i < val.Type().NumField(); i++ {
-					assert.EqualValues(t, expectedDialsTags[i], val.Type().Field(i).Tag.Get(DialsTagName))
+					assert.EqualValues(t, expectedDialsTags[i], val.Type().Field(i).Tag.Get(common.DialsTagName))
 					assert.EqualValues(t, expectedPathTags[i], val.Type().Field(i).Tag.Get(dialsFieldPathTag))
 				}
 
@@ -222,7 +223,7 @@ func TestFlattenMangler(t *testing.T) {
 				}
 
 				for i := 0; i < val.Type().NumField(); i++ {
-					assert.EqualValues(t, expectedDialsTags[i], val.Type().Field(i).Tag.Get(DialsTagName))
+					assert.EqualValues(t, expectedDialsTags[i], val.Type().Field(i).Tag.Get(common.DialsTagName))
 					assert.EqualValues(t, expectedFieldTags[i], val.Type().Field(i).Tag.Get(dialsFieldPathTag))
 
 				}
@@ -299,7 +300,7 @@ func TestFlattenMangler(t *testing.T) {
 				}
 
 				for i := 0; i < len(expectedTags); i++ {
-					assert.EqualValues(t, expectedTags[i], val.Type().Field(i).Tag.Get(DialsTagName))
+					assert.EqualValues(t, expectedTags[i], val.Type().Field(i).Tag.Get(common.DialsTagName))
 					assert.EqualValues(t, expectedFieldPathTag[i], val.Type().Field(i).Tag.Get(dialsFieldPathTag))
 
 				}
@@ -389,7 +390,7 @@ func TestFlattenMangler(t *testing.T) {
 
 				vtype := val.Type()
 				for i := 0; i < vtype.NumField(); i++ {
-					assert.EqualValues(t, expectedDialsTags[i], vtype.Field(i).Tag.Get(DialsTagName))
+					assert.EqualValues(t, expectedDialsTags[i], vtype.Field(i).Tag.Get(common.DialsTagName))
 					assert.EqualValues(t, expectedFieldTags[i], vtype.Field(i).Tag.Get(dialsFieldPathTag))
 					assert.EqualValues(t, expectedNames[i], vtype.Field(i).Name)
 				}
@@ -445,7 +446,7 @@ func TestFlattenMangler(t *testing.T) {
 
 				vtype := val.Type()
 				for i := 0; i < vtype.NumField(); i++ {
-					assert.EqualValues(t, expectedDialsTags[i], vtype.Field(i).Tag.Get(DialsTagName))
+					assert.EqualValues(t, expectedDialsTags[i], vtype.Field(i).Tag.Get(common.DialsTagName))
 					assert.EqualValues(t, expectedFieldTags[i], vtype.Field(i).Tag.Get(dialsFieldPathTag))
 					assert.EqualValues(t, expectedNames[i], vtype.Field(i).Name)
 				}
@@ -640,7 +641,7 @@ func TestTopLevelEmbed(t *testing.T) {
 
 	for i := 0; i < val.Type().NumField(); i++ {
 		assert.Equal(t, expectedNames[i], val.Type().Field(i).Name)
-		assert.EqualValues(t, expectedDialsTags[i], val.Type().Field(i).Tag.Get(DialsTagName))
+		assert.EqualValues(t, expectedDialsTags[i], val.Type().Field(i).Tag.Get(common.DialsTagName))
 		assert.EqualValues(t, expectedFieldTags[i], val.Type().Field(i).Tag.Get(dialsFieldPathTag))
 	}
 }

--- a/yaml/yaml.go
+++ b/yaml/yaml.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/vimeo/dials"
+	"github.com/vimeo/dials/common"
 	"github.com/vimeo/dials/tagformat"
 	"github.com/vimeo/dials/transform"
 
@@ -30,7 +31,7 @@ func (d *Decoder) Decode(r io.Reader, t *dials.Type) (reflect.Value, error) {
 
 	tfmr := transform.NewTransformer(t.Type(),
 		&tagformat.TagCopyingMangler{
-			SrcTag: transform.DialsTagName, NewTag: YAMLTagName},
+			SrcTag: common.DialsTagName, NewTag: YAMLTagName},
 	)
 	val, tfmErr := tfmr.Translate()
 	if tfmErr != nil {


### PR DESCRIPTION
Any field with a `dials` tag value of "-" will be skipped during pointerification. Additionally, `pflag` and `flag` package will not register flags for fields with "-" tag values. Note that nested struct fields will still be registered for pflag/flag packages.

Move `dials` tag to the `common` package to resolve import cycles