### PR TITLE
Flexible tagging decoding

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -31,7 +31,7 @@ func (e *Source) Value(t *dials.Type) (reflect.Value, error) {
 	// flatten the nested fields
 	flattenMangler := transform.NewFlattenMangler(common.DialsTagName, caseconversion.EncodeUpperCamelCase, caseconversion.EncodeUpperCamelCase)
 	// reformat the tags so they are SCREAMING_SNAKE_CASE
-	reformatTagMangler := tagformat.NewTagReformattingMangler(common.DialsTagName, caseconversion.DecodeGoCamelCase, caseconversion.EncodeUpperSnakeCase)
+	reformatTagMangler := tagformat.NewTagReformattingMangler(common.DialsTagName, caseconversion.DecodeGoTags, caseconversion.EncodeUpperSnakeCase)
 	// copy tags from "dials" to "dials_env" tag
 	tagCopyingMangler := &tagformat.TagCopyingMangler{SrcTag: common.DialsTagName, NewTag: envTagName}
 	// convert all the fields in the flattened struct to string type so the environment variables can be set

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -47,7 +47,7 @@ func TestEnv(t *testing.T) {
 		},
 		"string_with_dials_and_env_tags": {
 			ConfigStruct: &struct {
-				EnvVar string `dials:"ENV_ONE" dials_env:"ENV_TWO"`
+				EnvVar string `dials:"env-var" dials_env:"ENV_TWO"`
 			}{},
 			EnvVarName:  "ENV_TWO",
 			EnvVarValue: "asdf",

--- a/tagformat/caseconversion/case_conversion.go
+++ b/tagformat/caseconversion/case_conversion.go
@@ -105,20 +105,14 @@ func lastCharOfInitialismAtEOS(s string, i int) bool {
 	return i+rl == len(s) && unicode.IsUpper(r)
 }
 
-// TODO: Add EncodeGoCamelCase function and set as default name encoder in
-// FlattenMangler
-
-// DecodeGoCamelCase decodes UpperCamelCase and lowerCamelCase strings with
-// fully capitalized acronyms (e.g., "jsonAPIDocs") into a slice of lower-cased
-// sub-strings.
-func DecodeGoCamelCase(s string) (DecodedIdentifier, error) {
-	if !token.IsIdentifier(s) {
-		return nil, fmt.Errorf("Only characters of the Letter category or '_' can appear in strings")
-	}
+// decodeGoCamelCase splits up a string in a slice of lower cased sub-string by
+// splitting after fully capitalized acronyms and after the characters that
+// signal word boundaries as specified in the passed isWordBoundary function
+func decodeGoCamelCase(s string, isWordBoundary func(rune) bool) (DecodedIdentifier, error) {
 	words := []string{}
 	lastBoundary := 0
 	for i, char := range s {
-		if firstCharOfInitialism(s, i) || firstCharAfterInitialism(s, i) || char == '_' {
+		if firstCharOfInitialism(s, i) || firstCharAfterInitialism(s, i) || isWordBoundary(char) {
 			if lastBoundary < i {
 				word := s[lastBoundary:i]
 				if word == strings.ToUpper(word) {
@@ -127,8 +121,8 @@ func DecodeGoCamelCase(s string) (DecodedIdentifier, error) {
 					words = append(words, strings.ToLower(word))
 				}
 			}
-			switch char {
-			case '_':
+			switch {
+			case isWordBoundary(char):
 				lastBoundary = i + 1
 			default:
 				lastBoundary = i
@@ -153,48 +147,27 @@ func DecodeGoCamelCase(s string) (DecodedIdentifier, error) {
 	return words, nil
 }
 
-// DecodeGoTags is similar to DecodeGoCamelCase but slightly more flexible by
-// allowing hyphens (-) in addition to underscores (_) since go struct tags can
-// have these characters. The function will decode CamelCase and kebab-case
-// strings into a slice of lower cased strings.
+// TODO: Add EncodeGoCamelCase function and set as default name encoder in
+// FlattenMangler
+
+// DecodeGoCamelCase decodes UpperCamelCase and lowerCamelCase strings with
+// fully capitalized acronyms (e.g., "jsonAPIDocs") into a slice of lower-cased
+// sub-strings.
+func DecodeGoCamelCase(s string) (DecodedIdentifier, error) {
+	if !token.IsIdentifier(s) {
+		return nil, fmt.Errorf("Only characters of the Letter category or '_' can appear in strings")
+	}
+	return decodeGoCamelCase(s, func(r rune) bool {
+		return r == '_'
+	})
+}
+
+// DecodeGoTags decodes CamelCase, snake_case, and kebab-case strings with fully
+// capitalized acronyms into a slice of lower cased strings.
 func DecodeGoTags(s string) (DecodedIdentifier, error) {
-	words := []string{}
-	lastBoundary := 0
-	for i, char := range s {
-		if firstCharOfInitialism(s, i) || firstCharAfterInitialism(s, i) || char == '_' || char == '-' {
-			if lastBoundary < i {
-				word := s[lastBoundary:i]
-				if word == strings.ToUpper(word) {
-					words = append(words, extractInitialisms(word)...)
-				} else {
-					words = append(words, strings.ToLower(word))
-				}
-			}
-			switch char {
-			case '_', '-':
-				lastBoundary = i + 1
-			default:
-				lastBoundary = i
-			}
-
-		} else if lastCharOfInitialismAtEOS(s, i) {
-			if lastBoundary < i {
-				word := s[lastBoundary:]
-				if word == strings.ToUpper(word) {
-					words = append(words, extractInitialisms(word)...)
-					return words, nil
-				}
-			}
-			lastBoundary = i
-		}
-	}
-
-	if last := strings.ToLower(s[lastBoundary:]); len(last) > 0 {
-		words = append(words, strings.ToLower(s[lastBoundary:]))
-	}
-
-	return words, nil
-
+	return decodeGoCamelCase(s, func(r rune) bool {
+		return r == '_' || r == '-'
+	})
 }
 
 // List from https://github.com/golang/lint/blob/master/lint.go

--- a/tagformat/caseconversion/case_conversion.go
+++ b/tagformat/caseconversion/case_conversion.go
@@ -153,9 +153,10 @@ func DecodeGoCamelCase(s string) (DecodedIdentifier, error) {
 	return words, nil
 }
 
-// DecodeGoTags is similar to DecodeGoCamelCase but slightly more
-// flexible by allowing hyphen since go struct tags can have hyphens. Similar to
-// DecodeGoCamelCase, this will split the string according to the allowed characters and the initialisms
+// DecodeGoTags is similar to DecodeGoCamelCase but slightly more flexible by
+// allowing hyphens (-) in addition to underscores (_) since go struct tags can
+// have these characters. The function will decode CamelCase and kebab-case
+// strings into a slice of lower cased strings.
 func DecodeGoTags(s string) (DecodedIdentifier, error) {
 	words := []string{}
 	lastBoundary := 0

--- a/tagformat/caseconversion/case_conversion_test.go
+++ b/tagformat/caseconversion/case_conversion_test.go
@@ -64,6 +64,11 @@ var decodeCases = []struct {
 	{"decode_golangCamelCase_try_", []string{"decode", "golang", "camel", "case", "try"}, DecodeGoCamelCase, false},
 	{"A", []string{"a"}, DecodeGoCamelCase, false},
 	{"EnvVarA", []string{"env", "var", "a"}, DecodeGoCamelCase, false},
+
+	{"jsonAPI", []string{"json", "api"}, DecodeGoTags, false},
+	{"value-3", []string{"value", "3"}, DecodeGoTags, false},
+	{"decode_golangCamelCase_try_", []string{"decode", "golang", "camel", "case", "try"}, DecodeGoTags, false},
+	{"AB_Test-something_fun", []string{"ab", "test", "something", "fun"}, DecodeGoTags, false},
 }
 
 func TestDecode(t *testing.T) {


### PR DESCRIPTION
Create a flexible function that is similar to `DecodeGoCamelCase` but also allows hyphens. Use this function for reformat tag mangler in the env source instead of `DecodeGoCamelCase` function so dials tags that have hyphens in them (ex: flag fields) don't return an error while reformatting