### PR TITLE
Overlay: more deep-copies and add deep-copy consistency and recursive struct handling

### DIFF
--- a/deep_copy.go
+++ b/deep_copy.go
@@ -24,28 +24,15 @@ type ptrKey struct {
 
 func newDeepCopier() *deepCopier {
 	return &deepCopier{
-		ptrMap:   map[ptrKey]reflect.Value{},
-		sliceMap: map[uintptr]sliceInfo{},
-		mapMap:   map[uintptr]reflect.Value{},
+		ptrMap: map[ptrKey]reflect.Value{},
+		mapMap: map[uintptr]reflect.Value{},
 	}
-}
-
-type sliceInfo struct {
-	outBaseptr uintptr
-	maxCap     int
-	refs       []reflect.Value
 }
 
 type deepCopier struct {
 	// map from input pointer to output pointer to handle reference-cycles
 	// and splitting pointers to the same object.
 	ptrMap map[ptrKey]reflect.Value
-
-	// map from input slice-pointer to output-slice-pointer to handle
-	// reference cycles, and prevent splitting large backing arrays.
-	// Keeps back-references so if later references have larger capacities
-	// we can go back and fix those refs.
-	sliceMap map[uintptr]sliceInfo
 
 	// map from input map-pointer to output-map to handle
 	// reference cycles.
@@ -181,16 +168,8 @@ func (d *deepCopier) deepCopySlice(in, out reflect.Value) {
 		return
 	}
 
-	if in.Cap() > 0 {
-	}
-
 	if (out.IsNil() || out.Pointer() == in.Pointer()) && out.CanSet() {
 		out.Set(reflect.MakeSlice(in.Type(), in.Len(), in.Cap()))
-	}
-	d.sliceMap[in.Pointer()] = sliceInfo{
-		outBaseptr: out.Pointer(),
-		maxCap:     in.Cap(),
-		refs:       []reflect.Value{out},
 	}
 	// Copy the entire backing array
 	d.deepCopyArray(in.Slice(0, in.Cap()), out.Slice(0, out.Cap()))

--- a/dials.go
+++ b/dials.go
@@ -164,6 +164,7 @@ func compose(t interface{}, sources []sourceValue) (interface{}, error) {
 			s = s.Elem()
 		}
 		o := newOverlayer()
+		sv := o.dc.deepCopyValue(s)
 		if overlayErr := o.overlayStruct(value, sv); overlayErr != nil {
 			return nil, overlayErr
 		}

--- a/dials.go
+++ b/dials.go
@@ -163,7 +163,8 @@ func compose(t interface{}, sources []sourceValue) (interface{}, error) {
 		if s.Kind() == reflect.Ptr {
 			s = s.Elem()
 		}
-		if overlayErr := overlayStruct(value, s); overlayErr != nil {
+		o := newOverlayer()
+		if overlayErr := o.overlayStruct(value, sv); overlayErr != nil {
 			return nil, overlayErr
 		}
 

--- a/overlay_test.go
+++ b/overlay_test.go
@@ -383,7 +383,8 @@ func TestOverlay(t *testing.T) {
 
 			base := reflect.ValueOf(entry.base).Elem()
 			overlay := reflect.ValueOf(entry.overlay)
-			if err := overlayStruct(base, overlay); err != nil {
+			o := newOverlayer()
+			if err := o.overlayStruct(base, overlay); err != nil {
 				t.Fatalf("failed to overlay struct: %s",
 					err)
 			}


### PR DESCRIPTION
Deep copy between layers to allow for direct pointer assignment while overlaying.
Make deep-copy safe for use with structs containing self-referential pointers. Use the same method to dedup maps sharing a backing pointer.