### PR TITLE
Caseconversion return early

### DIFF
--- a/tagformat/caseconversion/case_conversion.go
+++ b/tagformat/caseconversion/case_conversion.go
@@ -301,9 +301,6 @@ func aggregateStringLen(words DecodedIdentifier) int {
 
 // EncodeUpperCamelCase encodes a slice of words into UpperCamelCase
 func EncodeUpperCamelCase(words DecodedIdentifier) string {
-	if len(words) == 0 {
-		return ""
-	}
 	b := strings.Builder{}
 	b.Grow(aggregateStringLen(words))
 	for _, w := range words {

--- a/tagformat/caseconversion/case_conversion.go
+++ b/tagformat/caseconversion/case_conversion.go
@@ -301,6 +301,9 @@ func aggregateStringLen(words DecodedIdentifier) int {
 
 // EncodeUpperCamelCase encodes a slice of words into UpperCamelCase
 func EncodeUpperCamelCase(words DecodedIdentifier) string {
+	if len(words) == 0 {
+		return ""
+	}
 	b := strings.Builder{}
 	b.Grow(aggregateStringLen(words))
 	for _, w := range words {
@@ -311,6 +314,9 @@ func EncodeUpperCamelCase(words DecodedIdentifier) string {
 
 // EncodeLowerCamelCase encodes a slice of words into lowerCamelCase
 func EncodeLowerCamelCase(words DecodedIdentifier) string {
+	if len(words) == 0 {
+		return ""
+	}
 	b := strings.Builder{}
 	b.Grow(aggregateStringLen(words))
 	b.WriteString(words[0])
@@ -327,6 +333,9 @@ func EncodeKebabCase(words DecodedIdentifier) string {
 
 // EncodeLowerSnakeCase encodes a slice of words into lower_snake_case
 func EncodeLowerSnakeCase(words DecodedIdentifier) string {
+	if len(words) == 0 {
+		return ""
+	}
 	b := strings.Builder{}
 	b.Grow(aggregateStringLen(words) + len(words) - 1)
 	for i, w := range words {
@@ -341,6 +350,9 @@ func EncodeLowerSnakeCase(words DecodedIdentifier) string {
 // EncodeUpperSnakeCase encodes a slice of words into UPPER_SNAKE_CASE (AKA
 // SCREAMING_SNAKE_CASE)
 func EncodeUpperSnakeCase(words DecodedIdentifier) string {
+	if len(words) == 0 {
+		return ""
+	}
 	b := strings.Builder{}
 	b.Grow(aggregateStringLen(words) + len(words) - 1)
 	for i, w := range words {

--- a/tagformat/caseconversion/case_conversion_test.go
+++ b/tagformat/caseconversion/case_conversion_test.go
@@ -94,11 +94,17 @@ var encodeCases = []struct {
 	encoderFunc func(DecodedIdentifier) string
 }{
 	{[]string{"upper", "camel", "case"}, "UpperCamelCase", EncodeUpperCamelCase},
+	{[]string{}, "", EncodeUpperCamelCase},
 	{[]string{"lower", "camel", "case"}, "lowerCamelCase", EncodeLowerCamelCase},
+	{[]string{}, "", EncodeLowerCamelCase},
 	{[]string{"kebab", "case", "string"}, "kebab-case-string", EncodeKebabCase},
+	{[]string{}, "", EncodeKebabCase},
 	{[]string{"loweR", "SNAKE", "Case"}, "lower_snake_case", EncodeLowerSnakeCase},
+	{[]string{}, "", EncodeLowerSnakeCase},
 	{[]string{"upper", "snake", "case"}, "UPPER_SNAKE_CASE", EncodeUpperSnakeCase},
+	{[]string{}, "", EncodeUpperSnakeCase},
 	{[]string{"case", "PRESERVING", "Snake"}, "case_PRESERVING_Snake", EncodeCasePreservingSnakeCase},
+	{[]string{}, "", EncodeCasePreservingSnakeCase},
 }
 
 func TestEncode(t *testing.T) {

--- a/transform/flatten_mangler_test.go
+++ b/transform/flatten_mangler_test.go
@@ -602,18 +602,26 @@ type Embed struct {
 	Bar bool   // will have dials tag "Bar" after flatten mangler
 }
 
+type EmbedNoTag struct {
+	World string
+}
+
 func TestTopLevelEmbed(t *testing.T) {
 	t.Parallel()
 	type Config struct {
 		unexposedHello string
 		Hello          string
 		Embed          `dials:"creative_name"`
+		EmbedNoTag
 	}
 
 	c := &Config{
 		unexposedHello: "hello world",
 		Embed: Embed{
 			Foo: "DoesThisWork",
+		},
+		EmbedNoTag: EmbedNoTag{
+			World: "hello world",
 		},
 	}
 	typeOfC := reflect.TypeOf(c)
@@ -626,17 +634,18 @@ func TestTopLevelEmbed(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedNames := []string{
-		"Hello", "Foo", "Bar",
+		"Hello", "Foo", "Bar", "World",
 	}
 
 	expectedDialsTags := []string{
 		"hello",
 		"creative_name_foofoo",
 		"creative_name_bar",
+		"world",
 	}
 
 	expectedFieldTags := []string{
-		"Hello", "Embed,Foo", "Embed,Bar",
+		"Hello", "Embed,Foo", "Embed,Bar", "EmbedNoTag,World",
 	}
 
 	for i := 0; i < val.Type().NumField(); i++ {


### PR DESCRIPTION
Return early when `len(word) ==0` in caseconversion encoding functions. The word slice will be 0 when we have top level embedded structs without any tags (we don't add tags to the embedded structs in the flatten mangler). The encoding functions would panic in 2 different cases. One is when we call `b.Grow(aggregateStringLen(words) + len(words) - 1)` which results in growing by -1. The second place is when we call `b.WriteString(words[0])` with index out of range for an empty slice. 

Add tests for caseconversion and flatten mangler