### PR TITLE
flag/flaghelper: tweaks to improve PrintDefaults output

### DIFF
--- a/flag/flag.go
+++ b/flag/flag.go
@@ -17,6 +17,7 @@ import (
 )
 
 var (
+	timeTime             = reflect.TypeOf(time.Time{})
 	timeDuration         = reflect.TypeOf(time.Nanosecond)
 	flagReflectType      = reflect.TypeOf((*flag.Value)(nil)).Elem()
 	stringSlice          = reflect.SliceOf(reflect.TypeOf(""))
@@ -209,6 +210,12 @@ func (s *Set) registerFlags(tmpl reflect.Value, ptyp reflect.Type) error {
 		fieldVal := transform.GetField(sf, tmpl)
 
 		switch {
+		case fieldVal.Type() == timeTime:
+			{
+				newVal := fieldVal.Interface().(time.Time)
+				s.Flags.Var(flaghelper.NewTimeWrapper(newVal), name, help)
+				continue
+			}
 		case isValue:
 			{
 

--- a/flag/flaghelper/marshal_wrapper.go
+++ b/flag/flaghelper/marshal_wrapper.go
@@ -18,6 +18,12 @@ func NewMarshalWrapper(v encoding.TextUnmarshaler) *MarshalWrapper {
 }
 
 func (w MarshalWrapper) String() string {
+	if m, ok := w.v.(encoding.TextMarshaler); ok {
+		b, err := m.MarshalText()
+		if err == nil {
+			return string(b)
+		}
+	}
 	if s, ok := w.v.(fmt.Stringer); ok {
 		return s.String()
 	}

--- a/flag/flaghelper/time.go
+++ b/flag/flaghelper/time.go
@@ -1,0 +1,36 @@
+package flaghelper
+
+import (
+	"time"
+)
+
+// TimeWrapper wraps a time.Time
+//
+// This is needed for the flag package in order to correctly
+// print or omit the default value in PrintDefaults.
+type TimeWrapper struct {
+	t time.Time
+}
+
+// NewTimeWrapper creates a new TimeWrapper for a time.Time
+func NewTimeWrapper(t time.Time) *TimeWrapper {
+	return &TimeWrapper{
+		t: t,
+	}
+}
+
+// Set implements flag.Value
+func (tw *TimeWrapper) Set(s string) error {
+	return tw.t.UnmarshalText([]byte(s))
+}
+
+// Get implements flag.Value
+func (tw *TimeWrapper) Get() interface{} {
+	return tw.t
+}
+
+// String implements flag.Value
+func (tw *TimeWrapper) String() string {
+	// This uses the same format as MarshalText but without the date range validation
+	return tw.t.Format(time.RFC3339Nano)
+}


### PR DESCRIPTION
- Better default handling for `time.Time` using a custom wrapper struct
- Better default printing for types that use `flaghelper.MarshalWrapper`