### PR TITLE
Config: deepcopy the template value

### DIFF
--- a/dials.go
+++ b/dials.go
@@ -21,7 +21,7 @@ func Config(ctx context.Context, t interface{}, sources ...Source) (*Dials, erro
 		return nil, fmt.Errorf("config type %T is not a pointer", t)
 	}
 
-	tVal := reflect.ValueOf(t)
+	tVal := realDeepCopy(t)
 
 	typeInstance := &Type{ptrify.Pointerify(typeOfT.Elem(), tVal.Elem())}
 	someoneWatching := false
@@ -51,7 +51,7 @@ func Config(ctx context.Context, t interface{}, sources ...Source) (*Dials, erro
 		}
 	}
 
-	newValue, err := compose(t, computed)
+	newValue, err := compose(tVal.Interface(), computed)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func Config(ctx context.Context, t interface{}, sources ...Source) (*Dials, erro
 	d.value.Store(newValue)
 
 	if someoneWatching {
-		go d.monitor(ctx, t, computed, watcherChan)
+		go d.monitor(ctx, tVal.Interface(), computed, watcherChan)
 	}
 	return d, nil
 }

--- a/dials_test.go
+++ b/dials_test.go
@@ -2,6 +2,7 @@ package dials
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,4 +25,79 @@ func TestFill(t *testing.T) {
 	filledConfig := &testConfig{}
 	d.Fill(filledConfig)
 	assert.Equal(t, "foo", filledConfig.Foo)
+}
+
+type fakeSource struct {
+	outVal interface{}
+}
+
+func (f *fakeSource) Value(t *Type) (reflect.Value, error) {
+	return reflect.ValueOf(f.outVal).Convert(t.t), nil
+}
+
+type fakeWatchingSource struct {
+	fakeSource
+	t  *Type
+	cb func(context.Context, reflect.Value)
+}
+
+func (f *fakeWatchingSource) Watch(_ context.Context, t *Type, cb func(context.Context, reflect.Value)) error {
+	f.cb = cb
+	f.t = t
+	return nil
+}
+
+func (f *fakeWatchingSource) send(ctx context.Context, val reflect.Value) {
+	f.cb(ctx, val.Convert(f.t.t))
+}
+
+func TestConfig(t *testing.T) {
+	type testConfig struct {
+		Foo string
+	}
+
+	type ptrifiedConfig struct {
+		Foo *string
+	}
+
+	base := testConfig{
+		Foo: "foo",
+	}
+	emptyConf := ptrifiedConfig{
+		Foo: nil,
+	}
+	// Push a new value, that should overlay on top of the base
+	foozleStr := "foozle"
+	foozleConfig := ptrifiedConfig{
+		Foo: &foozleStr,
+	}
+
+	// setup a cancelable context so the monitor goroutine gets shutdown.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := fakeWatchingSource{fakeSource: fakeSource{outVal: foozleConfig}}
+	d, err := Config(ctx, &base, &fakeSource{outVal: emptyConf}, &w)
+	require.NoError(t, err)
+
+	// pull in the existing value and verify that it works as intended.
+	// overwrite our original "base" to verify deep-copying is doing its job.
+	d.Fill(&base)
+	assert.Equal(t, "foozle", base.Foo)
+
+	// Push a new value, that should overlay on top of the base
+	fimStr := "fim"
+	fimConfig := ptrifiedConfig{
+		Foo: &fimStr,
+	}
+	w.send(ctx, reflect.ValueOf(fimConfig))
+	c := <-d.Events()
+	assert.Equal(t, "fim", c.(*testConfig).Foo)
+	assert.Equal(t, "fim", d.View().(*testConfig).Foo)
+
+	// push another empty config
+	w.send(ctx, reflect.ValueOf(emptyConf))
+	finalConf := <-d.Events()
+	assert.Equal(t, "foo", finalConf.(*testConfig).Foo)
+	assert.Equal(t, "foo", d.View().(*testConfig).Foo)
 }


### PR DESCRIPTION
Make a private copy of the default config (template) provided as an
argument to `Config` to avoid surprises when users modify the template
struct.

This is most important when a watching source is involved, as we now
have a long-lived reference to our template struct.

A natural way users will try to use the `Fill()` method (that we had
failed to anticipate) was to pass the template variable to that struct
directly.

Without this deep-copy, using `Fill()` in this way is:
 - thread unsafe, since the watcher assumes that value is immutible and
   hence is read without synchronization
 - surprising, since the current config becomes the default config,
   making removal of fields from config files default to the existing
   value, rather htan the normal default that was passed (as the
   base-layer) to dials.

Add a test verifying this behavior.