### PR TITLE
SetSliceMangler

### DIFF
--- a/ez/ez.go
+++ b/ez/ez.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vimeo/dials/json"
 	"github.com/vimeo/dials/sourcewrap"
 	"github.com/vimeo/dials/toml"
+	"github.com/vimeo/dials/transform"
 	"github.com/vimeo/dials/yaml"
 )
 
@@ -20,14 +21,16 @@ import (
 type Option func(*dialsOptions)
 
 type dialsOptions struct {
-	watch      bool
-	flagConfig *flag.NameConfig
+	watch          bool
+	flagConfig     *flag.NameConfig
+	autoSetToSlice bool
 }
 
 func getDefaultOption() *dialsOptions {
 	return &dialsOptions{
-		watch:      false,
-		flagConfig: flag.DefaultFlagNameConfig(),
+		watch:          false,
+		flagConfig:     flag.DefaultFlagNameConfig(),
+		autoSetToSlice: true,
 	}
 }
 
@@ -37,9 +40,16 @@ func WithFlagConfig(flagConfig *flag.NameConfig) Option {
 }
 
 // WithWatchingConfigFile allows to watch the config file by using the watching
-// file source
-func WithWatchingConfigFile() Option {
-	return func(d *dialsOptions) { d.watch = true }
+// file source.  This defaults to false.
+func WithWatchingConfigFile(enabled bool) Option {
+	return func(d *dialsOptions) { d.watch = enabled }
+}
+
+// WithAutoSetToSlice allows you to set whether sets (map[string]struct{})
+// should be automatically converted to slices ([]string) so they can be
+// naturally parsed by JSON, YAML, or TOML parsers.  This defaults to true.
+func WithAutoSetToSlice(enabled bool) Option {
+	return func(d *dialsOptions) { d.autoSetToSlice = enabled }
 }
 
 // DecoderFactory should return the appropriate decoder based on the config file
@@ -105,9 +115,17 @@ func ConfigFileEnvFlag(ctx context.Context, cfg ConfigWithConfigPath, df Decoder
 		// file after all.
 		return d, nil
 	}
+
 	decoder := df(cfgPath)
 	if decoder == nil {
 		return nil, fmt.Errorf("decoderFactory provided a nil decoder")
+	}
+
+	if option.autoSetToSlice {
+		decoder = sourcewrap.NewTransformingDecoder(
+			decoder,
+			&transform.SetSliceMangler{},
+		)
 	}
 
 	fileSrc, fileErr := fileSource(cfgPath, decoder, option.watch)

--- a/ez/ez_test.go
+++ b/ez/ez_test.go
@@ -12,9 +12,10 @@ import (
 type Config struct {
 	// Path will contain the path to the config file and will be set by
 	// environment variable
-	Path string `dials:"CONFIGPATH"`
-	Val1 int    `dials:"Val1"`
-	Val2 string `dials:"Val2"`
+	Path string              `dials:"CONFIGPATH"`
+	Val1 int                 `dials:"Val1"`
+	Val2 string              `dials:"Val2"`
+	Set  map[string]struct{} `dials:"Set"`
 }
 
 // ConfigPath reflects where the path to config file is stored. Path field
@@ -42,6 +43,11 @@ func TestYAMLConfigEnvFlag(t *testing.T) {
 		Path: "../testhelper/testconfig.yaml",
 		Val1: 456,
 		Val2: "hello-world",
+		Set: map[string]struct{}{
+			"Keith": {},
+			"Gary":  {},
+			"Jack":  {},
+		},
 	}
 	populatedConf := view.View().(*Config)
 	assert.EqualValues(t, expectedConfig, *populatedConf)

--- a/sourcewrap/transforming_source.go
+++ b/sourcewrap/transforming_source.go
@@ -34,8 +34,13 @@ func (t *transformingDecoder) Decode(reader io.Reader, typ *dials.Type) (reflect
 	if srcErr != nil {
 		return reflect.Value{}, &wrappedErr{prefix: "inner source failed: ", err: srcErr}
 	}
-	return srcVal, nil
 
+	retVal, revErr := tfm.ReverseTranslate(srcVal)
+	if revErr != nil {
+		return reflect.Value{}, &wrappedErr{prefix: "inner reverse translate failed: ", err: revErr}
+	}
+
+	return retVal, nil
 }
 
 // NewTransformingSource constructs a dials.Source wrapping a slice of

--- a/sourcewrap/transforming_source_test.go
+++ b/sourcewrap/transforming_source_test.go
@@ -1,0 +1,64 @@
+package sourcewrap
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vimeo/dials"
+	"github.com/vimeo/dials/static"
+	"github.com/vimeo/dials/transform"
+)
+
+type trivialJSONDecoder struct{}
+
+func (tjd *trivialJSONDecoder) Decode(r io.Reader, dt *dials.Type) (reflect.Value, error) {
+	jsonBytes, err := ioutil.ReadAll(r)
+	if err != nil {
+		return reflect.Value{}, fmt.Errorf("error reading JSON: %s", err)
+	}
+
+	val := reflect.New(dt.Type()).Elem()
+
+	instance := val.Addr().Interface()
+	err = json.Unmarshal(jsonBytes, instance)
+	if err != nil {
+		return reflect.Value{}, err
+	}
+
+	return val, nil
+}
+
+func TestTransformingDecoder(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	type conf struct {
+		Set map[string]struct{}
+	}
+
+	c := conf{}
+
+	ss := static.StringSource{
+		Data: `{"Set": ["a", "b", "c"]}`,
+		Decoder: NewTransformingDecoder(
+			&trivialJSONDecoder{},
+			&transform.SetSliceMangler{},
+		),
+	}
+
+	d, err := dials.Config(ctx, &c, &ss)
+	require.NoError(t, err)
+
+	theConf := d.View().(*conf)
+	assert.Len(t, theConf.Set, 3)
+	assert.Contains(t, theConf.Set, "a")
+	assert.Contains(t, theConf.Set, "b")
+	assert.Contains(t, theConf.Set, "c")
+}

--- a/testhelper/testconfig.yaml
+++ b/testhelper/testconfig.yaml
@@ -1,2 +1,6 @@
 Val1: 456
 Val2: hello-world
+Set:
+  - Keith
+  - Gary
+  - Jack

--- a/transform/set_slice_mangler.go
+++ b/transform/set_slice_mangler.go
@@ -1,0 +1,65 @@
+package transform
+
+import (
+	"fmt"
+	"reflect"
+)
+
+var (
+	emptyStructValue = reflect.ValueOf(struct{}{})
+	emptyStructType  = emptyStructValue.Type()
+)
+
+// SetSliceMangler conveniently maps from sets (e.g. map[string]struct{}) to
+// slices (e.g. []string)
+type SetSliceMangler struct {
+}
+
+// Mangle changes the type of the provided StructField from a map[T]struct{} to
+// []T.
+func (*SetSliceMangler) Mangle(sf reflect.StructField) ([]reflect.StructField, error) {
+	if sf.Type.Kind() == reflect.Map && sf.Type.Elem() == emptyStructType {
+		sf.Type = reflect.SliceOf(sf.Type.Key())
+	}
+
+	return []reflect.StructField{sf}, nil
+}
+
+// Unmangle turns []T back into a map[T]struct{}.  Naturally, deduplication will
+// occur.
+func (*SetSliceMangler) Unmangle(sf reflect.StructField, vs []FieldValueTuple) (reflect.Value, error) {
+	if !(sf.Type.Kind() == reflect.Map && sf.Type.Elem() == emptyStructType) {
+		return vs[0].Value, nil
+	}
+
+	slice := vs[0].Value
+
+	if slice.Kind() != reflect.Slice {
+		return reflect.Value{}, fmt.Errorf(
+			"expected slice to unmangle, instead got %s",
+			slice.Kind(),
+		)
+	}
+
+	if slice.Type().Elem() != sf.Type.Key() {
+		return reflect.Value{}, fmt.Errorf(
+			"expected slice elem to be %q, got %q",
+			slice.Type().Elem(),
+			sf.Type.Key(),
+		)
+	}
+
+	// slice.Len() could be larger if there are duplicates, but it's likely
+	// a good place to start.
+	set := reflect.MakeMapWithSize(sf.Type, slice.Len())
+	for i := 0; i < slice.Len(); i++ {
+		set.SetMapIndex(slice.Index(i), emptyStructValue)
+	}
+
+	return set, nil
+}
+
+// ShouldRecurse always returns true in order to walk nested structs.
+func (*SetSliceMangler) ShouldRecurse(reflect.StructField) bool {
+	return true
+}

--- a/transform/set_slice_mangler_test.go
+++ b/transform/set_slice_mangler_test.go
@@ -1,0 +1,83 @@
+package transform
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vimeo/dials/ptrify"
+)
+
+func TestSetSliceManglerMangle(t *testing.T) {
+	m := SetSliceMangler{}
+	sf := reflect.StructField{
+		Type: reflect.TypeOf(map[string]struct{}{}),
+	}
+	sfs, err := m.Mangle(sf)
+
+	require.NoError(t, err)
+
+	assert.Equal(t, reflect.TypeOf([]string{}), sfs[0].Type)
+}
+
+func TestSetSliceManglerUnmangle(t *testing.T) {
+	cases := map[string]struct {
+		StructFieldType reflect.Type
+		SrcValue        interface{}
+		ExpectedMap     interface{}
+	}{
+		"stringSet": {
+			StructFieldType: reflect.TypeOf(map[string]struct{}{}),
+			SrcValue:        []string{"John", "Paul", "George", "Ringo"},
+			ExpectedMap: map[string]struct{}{
+				"John":   {},
+				"Paul":   {},
+				"George": {},
+				"Ringo":  {},
+			},
+		},
+		"intSet": {
+			StructFieldType: reflect.TypeOf(map[int]struct{}{}),
+			SrcValue:        []int{1, 2, 3},
+			ExpectedMap: map[int]struct{}{
+				1: {},
+				2: {},
+				3: {},
+			},
+		},
+		"setWithDuplicates": {
+			StructFieldType: reflect.TypeOf(map[string]struct{}{}),
+			SrcValue:        []string{"foo", "foo", "bar", "baz"},
+			ExpectedMap: map[string]struct{}{
+				"foo": {},
+				"bar": {},
+				"baz": {},
+			},
+		},
+	}
+
+	for name, c := range cases {
+		testCase := c
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			sf := reflect.StructField{Name: "ConfigField", Type: testCase.StructFieldType}
+			configStructType := reflect.StructOf([]reflect.StructField{sf})
+			ptrifiedConfigType := ptrify.Pointerify(configStructType, reflect.New(configStructType).Elem())
+
+			m := &SetSliceMangler{}
+			tfmr := NewTransformer(ptrifiedConfigType, m)
+
+			val, err := tfmr.Translate()
+			require.NoError(t, err)
+
+			val.Field(0).Set(reflect.ValueOf(testCase.SrcValue))
+
+			unmangledVal, err := tfmr.ReverseTranslate(val)
+			require.NoError(t, err)
+
+			assert.Equal(t, testCase.ExpectedMap, unmangledVal.FieldByName("ConfigField").Interface())
+		})
+	}
+}


### PR DESCRIPTION
This adds the `SetSliceMangler` that allows us to easily parse lists in formats like JSON, YAML, or TOML into go "sets," commonly implemented as `map[T]struct{}`.  In the `ez` package this option will be enabled by default and can be disabled by adding the `WithAutoSetToSlice` option.

It also fixes a bug in the `TransformingDecoder` that was omitting a necessary call to `ReverseTranslate`.