### PR TITLE
Unembed the anonymous fields in flatten mangler

### DIFF
--- a/env/env_test.go
+++ b/env/env_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,8 +13,9 @@ import (
 
 func TestEnv(t *testing.T) {
 	type Embed struct {
-		Foo int
-		Bar bool
+		Foo      int
+		Bar      bool
+		SomeTime time.Duration
 	}
 	cases := map[string]struct {
 		ConfigStruct interface{}

--- a/flag/flag_test.go
+++ b/flag/flag_test.go
@@ -17,8 +17,9 @@ func TestDirectBasic(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 	type Embed struct {
-		Foo string `dialsflag:"foofoo"`
-		Bar bool   // will have dials tag "bar" after flatten mangler
+		Foo      string `dialsflag:"foofoo"`
+		Bar      bool   // will have dials tag "bar" after flatten mangler
+		SomeTime time.Duration
 	}
 	type Config struct {
 		Hello string
@@ -29,7 +30,7 @@ func TestDirectBasic(t *testing.T) {
 	src := &Set{
 		Flags: fs,
 		ParseFunc: func() error {
-			return fs.Parse([]string{"-world", "-hello=foobar", "-foofoo=something", "-bar"})
+			return fs.Parse([]string{"-world", "-hello=foobar", "-foofoo=something", "-bar", "-some-time=2s"})
 		},
 	}
 	buf := &bytes.Buffer{}
@@ -60,6 +61,10 @@ func TestDirectBasic(t *testing.T) {
 
 	if !got.Bar {
 		t.Errorf("expected Bar to be true, got %t", got.Bar)
+	}
+
+	if got.SomeTime != 2*time.Second {
+		t.Errorf("expected SomeTime to be 2s, got %s", got.SomeTime)
 	}
 }
 

--- a/pflag/pflag_test.go
+++ b/pflag/pflag_test.go
@@ -18,8 +18,9 @@ func TestDirectBasicPFlag(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 	type Embed struct {
-		Foo string `dialspflag:"foofoo"`
-		Bar bool   // will have dials tag "bar" after flatten mangler
+		Foo      string `dialspflag:"foofoo"`
+		Bar      bool   // will have dials tag "bar" after flatten mangler
+		SomeTime time.Duration
 	}
 	type Config struct {
 		Hello string
@@ -31,7 +32,7 @@ func TestDirectBasicPFlag(t *testing.T) {
 	src := &Set{
 		Flags: fs,
 		ParseFunc: func() error {
-			return fs.Parse([]string{"--world", "--hello=foobar", "--foofoo=something", "--bar"})
+			return fs.Parse([]string{"--world", "--hello=foobar", "--foofoo=something", "--bar", "--some-time=2s"})
 		},
 	}
 	buf := &bytes.Buffer{}
@@ -62,6 +63,10 @@ func TestDirectBasicPFlag(t *testing.T) {
 
 	if !got.Bar {
 		t.Errorf("expected Bar to be true, got %t", got.Bar)
+	}
+
+	if got.SomeTime != 2*time.Second {
+		t.Errorf("expected SomeTime to be 2s, got %s", got.SomeTime)
 	}
 }
 

--- a/transform/flatten_mangler.go
+++ b/transform/flatten_mangler.go
@@ -89,7 +89,7 @@ func (f *FlattenMangler) Mangle(sf reflect.StructField) ([]reflect.StructField, 
 		Name:      name,
 		Type:      sf.Type,
 		Tag:       tag,
-		Anonymous: sf.Anonymous,
+		Anonymous: false, // un-embed the embedded fields
 	}
 	out = []reflect.StructField{newsf}
 
@@ -150,7 +150,7 @@ func (f *FlattenMangler) flattenStruct(fieldPrefix, tagPrefix, fieldPath []strin
 			Name:      name,
 			Type:      nestedsf.Type,
 			Tag:       tag,
-			Anonymous: sf.Anonymous,
+			Anonymous: false, // un-embed the embedded fields
 		}
 		out = append(out, newSF)
 	}

--- a/transform/flatten_mangler_test.go
+++ b/transform/flatten_mangler_test.go
@@ -26,6 +26,7 @@ func TestFlattenMangler(t *testing.T) {
 	type Foo struct {
 		Location    string `dials:"Location"`
 		Coordinates int    `dials:"Coordinates"`
+		SomeTime    time.Duration
 	}
 
 	type bar struct {
@@ -60,6 +61,7 @@ func TestFlattenMangler(t *testing.T) {
 		Foo: Foo{
 			Location:    "here",
 			Coordinates: 64,
+			SomeTime:    2 * time.Second,
 		},
 		AnotherField: 42,
 	}
@@ -69,6 +71,7 @@ func TestFlattenMangler(t *testing.T) {
 		Foo{
 			Location:    "here",
 			Coordinates: 64,
+			SomeTime:    2 * time.Second,
 		},
 		42,
 	}
@@ -212,6 +215,7 @@ func TestFlattenMangler(t *testing.T) {
 					"config_field_Name",
 					"config_field_Foobar_Location",
 					"config_field_Foobar_Coordinates",
+					"config_field_Foobar_some_time",
 					"config_field_AnotherField",
 				}
 
@@ -219,6 +223,7 @@ func TestFlattenMangler(t *testing.T) {
 					"ConfigField,Name",
 					"ConfigField,Foobar,Location",
 					"ConfigField,Foobar,Coordinates",
+					"ConfigField,Foobar,SomeTime",
 					"ConfigField,AnotherField",
 				}
 
@@ -232,11 +237,13 @@ func TestFlattenMangler(t *testing.T) {
 				s2 := "here"
 				i1 := 64
 				i2 := 42
+				t1 := 2 * time.Second
 
 				val.Field(0).Set(reflect.ValueOf(&s1))
 				val.Field(1).Set(reflect.ValueOf(&s2))
 				val.Field(2).Set(reflect.ValueOf(&i1))
-				val.Field(3).Set(reflect.ValueOf(&i2))
+				val.Field(3).Set(reflect.ValueOf(&t1))
+				val.Field(4).Set(reflect.ValueOf(&i2))
 			},
 			assertion: func(t testing.TB, i interface{}) {
 				// all the fields are pointerified because of call to Pointerify
@@ -244,11 +251,13 @@ func TestFlattenMangler(t *testing.T) {
 				s2 := "here"
 				i1 := 64
 				i2 := 42
+				t1 := 2 * time.Second
 				b := struct {
 					Name   *string `dials:"Name"`
 					Foobar *struct {
 						Location    *string `dials:"Location"`
 						Coordinates *int    `dials:"Coordinates"`
+						SomeTime    *time.Duration
 					} `dials:"Foobar"`
 					AnotherField *int `dials:"AnotherField"`
 				}{
@@ -256,9 +265,11 @@ func TestFlattenMangler(t *testing.T) {
 					Foobar: &struct {
 						Location    *string `dials:"Location"`
 						Coordinates *int    `dials:"Coordinates"`
+						SomeTime    *time.Duration
 					}{
 						Location:    &s2,
 						Coordinates: &i1,
+						SomeTime:    &t1,
 					},
 					AnotherField: &i2,
 				}
@@ -371,6 +382,7 @@ func TestFlattenMangler(t *testing.T) {
 					"config_field_Name",
 					"config_field_Location",
 					"config_field_Coordinates",
+					"config_field_some_time",
 					"config_field_AnotherField",
 				}
 
@@ -378,6 +390,7 @@ func TestFlattenMangler(t *testing.T) {
 					"ConfigField,Name",
 					"ConfigField,Foo,Location",
 					"ConfigField,Foo,Coordinates",
+					"ConfigField,Foo,SomeTime",
 					"ConfigField,AnotherField",
 				}
 
@@ -385,6 +398,7 @@ func TestFlattenMangler(t *testing.T) {
 					"ConfigFieldName",
 					"ConfigFieldLocation",
 					"ConfigFieldCoordinates",
+					"ConfigFieldSomeTime",
 					"ConfigFieldAnotherField",
 				}
 
@@ -399,11 +413,13 @@ func TestFlattenMangler(t *testing.T) {
 				s2 := "here"
 				i1 := 64
 				i2 := 42
+				t1 := 2 * time.Second
 
 				val.Field(0).Set(reflect.ValueOf(&s1))
 				val.Field(1).Set(reflect.ValueOf(&s2))
 				val.Field(2).Set(reflect.ValueOf(&i1))
-				val.Field(3).Set(reflect.ValueOf(&i2))
+				val.Field(3).Set(reflect.ValueOf(&t1))
+				val.Field(4).Set(reflect.ValueOf(&i2))
 			},
 			assertion: func(t testing.TB, i interface{}) {
 				// embedded fields are hard to compare with defined structs because
@@ -427,6 +443,7 @@ func TestFlattenMangler(t *testing.T) {
 					"config_field_Name",
 					"config_field_embeddedFoo_Location",
 					"config_field_embeddedFoo_Coordinates",
+					"config_field_embeddedFoo_some_time",
 					"config_field_AnotherField",
 				}
 
@@ -434,6 +451,7 @@ func TestFlattenMangler(t *testing.T) {
 					"ConfigField,Name",
 					"ConfigField,Foo,Location",
 					"ConfigField,Foo,Coordinates",
+					"ConfigField,Foo,SomeTime",
 					"ConfigField,AnotherField",
 				}
 
@@ -441,6 +459,7 @@ func TestFlattenMangler(t *testing.T) {
 					"ConfigFieldName",
 					"ConfigFieldLocation",
 					"ConfigFieldCoordinates",
+					"ConfigFieldSomeTime",
 					"ConfigFieldAnotherField",
 				}
 
@@ -455,11 +474,13 @@ func TestFlattenMangler(t *testing.T) {
 				s2 := "here"
 				i1 := 64
 				i2 := 42
+				t1 := 2 * time.Second
 
 				val.Field(0).Set(reflect.ValueOf(&s1))
 				val.Field(1).Set(reflect.ValueOf(&s2))
 				val.Field(2).Set(reflect.ValueOf(&i1))
-				val.Field(3).Set(reflect.ValueOf(&i2))
+				val.Field(3).Set(reflect.ValueOf(&t1))
+				val.Field(4).Set(reflect.ValueOf(&i2))
 			},
 			assertion: func(t testing.TB, i interface{}) {
 				// assert.EqualValues doesn't work here with the embedded structs


### PR DESCRIPTION
Fix bug in flatten mangler where nested fields in embedded structs were flattened as anonymous fields. This results in a panic `panic: reflect: embedded type with methods not implemented if type is not first field` for embedded fields of type `time.Time` because that field was now a top level embedded field. This PR unembeds the embedded fields in the flatten mangler and adds fields with `time.Time` type in embedded struct tests