### PR TITLE
pflag option in ez package

### DIFF
--- a/ez/ez.go
+++ b/ez/ez.go
@@ -106,10 +106,8 @@ func ConfigFileEnvFlag(ctx context.Context, cfg ConfigWithConfigPath, df Decoder
 		o(option)
 	}
 
-	var flagSrc dials.Source
-	if option.flagSubstitute != nil {
-		flagSrc = option.flagSubstitute
-	} else {
+	flagSrc := option.flagSubstitute
+	if flagSrc == nil {
 		// flag source isn't substituted so use the flag source
 		fset, flagErr := flag.NewCmdLineSet(option.flagConfig, cfg)
 		if flagErr != nil {


### PR DESCRIPTION
Add a pflag specific option in the ez package. The implementation is general so we can substitute any sources for the flag package and add more source options in the future 