### PR TITLE
Allow more characters in unquoted strings in parsed maps and slices

### DIFF
--- a/parse/map_test.go
+++ b/parse/map_test.go
@@ -69,6 +69,35 @@ func TestParseMapForStringStringMaps(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			name:  "origin_referer_unquoted",
+			input: `Origin: foobar, Referer: fimbat`,
+			expected: map[string]string{
+				"Origin":  "foobar",
+				"Referer": "fimbat",
+			},
+			expectedStr: `"Origin":"foobar","Referer":"fimbat"`,
+			expectedErr: nil,
+		},
+		{
+			name:  "paths_unquoted",
+			input: `src: /etc/foo/limits.conf, src2: /etc/foo/limits3.conf`,
+			expected: map[string]string{
+				"src":  "/etc/foo/limits.conf",
+				"src2": "/etc/foo/limits3.conf",
+			},
+			expectedStr: `"src":"/etc/foo/limits.conf","src2":"/etc/foo/limits3.conf"`,
+			expectedErr: nil,
+		},
+		{
+			name:  "prices_unquoted",
+			input: `us:$22.33,uk:33.44£,ja:777¥`,
+			expected: map[string]string{
+				"us": "$22.33", "uk": "33.44£", "ja": "777¥",
+			},
+			expectedStr: `us:$22.33,uk:33.44£,ja:777¥`,
+			expectedErr: nil,
+		},
+		{
 			name:        "naked_colon",
 			input:       `:`,
 			expected:    nil,

--- a/parse/split_string_slice.go
+++ b/parse/split_string_slice.go
@@ -41,7 +41,9 @@ func splitStringsSlice(s string, addVal func(val string) error) error {
 		if (ch < ' ' && ch >= 0) && (sc.Whitespace&(1<<ch) > 0) {
 			return false
 		}
-		if unicode.IsLetter(ch) || unicode.IsDigit(ch) || unicode.IsPrint(ch) {
+		// IsPrint includes letter, number, symbol and a couple other
+		// character-classes
+		if unicode.IsPrint(ch) {
 			return true
 		}
 		return false

--- a/parse/string_set_test.go
+++ b/parse/string_set_test.go
@@ -94,6 +94,27 @@ func TestParseStringSet(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			name:        "unquoted_urls",
+			input:       "http://vimeo.com/fim.jpg,https://vimeo.com/foo.jpg",
+			expected:    sv("http://vimeo.com/fim.jpg", "https://vimeo.com/foo.jpg"),
+			expectedStr: `"http://vimeo.com/fim.jpg","https://vimeo.com/foo.jpg"`,
+			expectedErr: nil,
+		},
+		{
+			name:        "unquoted_currencies",
+			input:       "$32.00,22¢,28£,8888¥",
+			expected:    sv("$32.00", "22¢", "28£", "8888¥"),
+			expectedStr: `$32.00,22¢,28£,8888¥`,
+			expectedErr: nil,
+		},
+		{
+			name:        "unquoted_parenthesised_currencies",
+			input:       "($32.00),(22¢),(28£),(8888¥)",
+			expected:    sv("($32.00)", "(22¢)", "(28£)", "(8888¥)"),
+			expectedStr: `($32.00),(22¢),(28£),(8888¥)`,
+			expectedErr: nil,
+		},
+		{
 			name:        "unclosed_quotes",
 			input:       "`a,`, `,b",
 			expected:    nil,

--- a/parse/string_slice_test.go
+++ b/parse/string_slice_test.go
@@ -73,6 +73,27 @@ func TestParseStringSlice(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			name:        "unquoted_urls",
+			input:       "http://vimeo.com/fim.jpg,https://vimeo.com/foo.jpg",
+			expected:    []string{"http://vimeo.com/fim.jpg", "https://vimeo.com/foo.jpg"},
+			expectedStr: `"http://vimeo.com/fim.jpg","https://vimeo.com/foo.jpg"`,
+			expectedErr: nil,
+		},
+		{
+			name:        "unquoted_currencies",
+			input:       "$32.00,22¢,28£,8888¥",
+			expected:    []string{"$32.00", "22¢", "28£", "8888¥"},
+			expectedStr: `$32.00,22¢,28£,8888¥`,
+			expectedErr: nil,
+		},
+		{
+			name:        "unquoted_parenthesised_currencies",
+			input:       "($32.00),(22¢),(28£),(8888¥)",
+			expected:    []string{"($32.00)", "(22¢)", "(28£)", "(8888¥)"},
+			expectedStr: `($32.00),(22¢),(28£),(8888¥)`,
+			expectedErr: nil,
+		},
+		{
 			name:        "two_strings_with_commas_and_escaped_quotes",
 			input:       "\",a\",\"b,\\\"\"",
 			expected:    []string{",a", "b,\""},


### PR DESCRIPTION
Allow almost all printing characters when parsing `map[string]string`, `map[string]struct{}`, `map[string][]string` and `[]string` types. This will allow colons (`:`) in slice and set-types, and `/`s, `.`s, mixed numbers and letters and currency/special characters in all types.

This does specifically disallow all types of quotes and whitespace from being unquoted.