### PR TITLE
VerifiedConfig interface, Watcher error handing and plumbing

### DIFF
--- a/dials.go
+++ b/dials.go
@@ -141,6 +141,9 @@ type watchTab struct {
 // Watcher should be implemented by Sources that allow their configuration to be
 // watched for changes.
 type Watcher interface {
+	// Watch will be called in the primary goroutine calling Config(). If
+	// Watcher implementations need a persistent goroutine, they should
+	// spawn it themselves.
 	Watch(context.Context, *Type, func(context.Context, reflect.Value)) error
 }
 

--- a/dials.go
+++ b/dials.go
@@ -10,11 +10,41 @@ import (
 	"github.com/vimeo/dials/ptrify"
 )
 
+// WatchedErrorHandler is a callback that's called when something fails when
+// dials is operating in a watching mode.  Both oldConfig and NewConfig are
+// guaranteed to be populated with the same pointer-type that was passed to
+// `Config()`.
+type WatchedErrorHandler func(ctx context.Context, err error, oldConfig, newConfig interface{})
+
+// Params provides options for setting Dials's behavior in some cases.
+type Params struct {
+	// OnWatchedError is called when either of several conditions are met:
+	//  - There is an error re-stacking the configuration
+	//  -
+	//  - a Verify() method fails after re-stacking when a new version is
+	//    provided by a watching source
+	OnWatchedError WatchedErrorHandler
+}
+
 // Config populates the passed in config struct by reading the values from the
 // different Sources. The order of the sources denotes the precedence of the formats
 // so the last source passed to the function has the ability to override fields that
 // were set by previous sources
-func Config(ctx context.Context, t interface{}, sources ...Source) (*Dials, error) {
+//
+// If present, a Verify() method will be called after each stacking attempt.
+// Blocking/expensive work should not be done in this method. (see the comment
+// on Verify()) in VerifiedConfig for details)
+//
+// If complicated/blocking initialization/verification is necessary, one can either:
+//  - If not using any watching sources, do any verification with the returned
+//    config from Config.
+//  - If using at least one watching source, configure a goroutine to watch the
+//    channel returned by the `Dials.Events()` method that does its own
+//    installation after verifying the config.
+//
+// More complicated verification/initialization should be done by
+// consuming from the channel returned by `Events()`.
+func (p Params) Config(ctx context.Context, t interface{}, sources ...Source) (*Dials, error) {
 
 	watcherChan := make(chan *watchTab)
 	computed := make([]sourceValue, 0, len(sources))
@@ -65,10 +95,27 @@ func Config(ctx context.Context, t interface{}, sources ...Source) (*Dials, erro
 	}
 	d.value.Store(newValue)
 
+	// Verify that the configuration is valid if a Verify() method is present.
+	if vf, ok := newValue.(VerifiedConfig); ok {
+		if vfErr := vf.Verify(); vfErr != nil {
+			return nil, fmt.Errorf("Initial configuration verification failed: %w", vfErr)
+		}
+	}
+
 	if someoneWatching {
 		go d.monitor(ctx, tVal.Interface(), computed, watcherChan)
 	}
 	return d, nil
+}
+
+// Config populates the passed in config struct by reading the values from the
+// different Sources. The order of the sources denotes the precedence of the formats
+// so the last source passed to the function has the ability to override fields that
+// were set by previous sources
+// This top-level function is present for convenience and backwards
+// compatibility when there is no need to specify an error-handler.
+func Config(ctx context.Context, t interface{}, sources ...Source) (*Dials, error) {
+	return Params{}.Config(ctx, t, sources...)
 }
 
 // Source interface is implemented by each configuration source that is used to
@@ -94,6 +141,17 @@ type watchTab struct {
 // watched for changes.
 type Watcher interface {
 	Watch(context.Context, *Type, func(context.Context, reflect.Value)) error
+}
+
+// VerifiedConfig implements the Verify method, allowing Dials to execute the
+// Verify method before returning/installing a new version of the
+// configuration.
+type VerifiedConfig interface {
+	// Verify() should return a non-nil error if the configuration is
+	// invalid.
+	// As this method is called any time the configuration sources are
+	// restacked, it should not do any complex or blocking work.
+	Verify() error
 }
 
 // Dials is the main access point for your configuration.

--- a/dials_test.go
+++ b/dials_test.go
@@ -149,7 +149,7 @@ func TestConfigWithFailVerifier(t *testing.T) {
 	}
 }
 
-// successVerifier is a struct with a Verify() method that always fails with an error
+// successVerifier is a struct with a Verify() method that never fails with an error
 type successVerifier struct{}
 
 func (successVerifier) Verify() error {

--- a/dials_test.go
+++ b/dials_test.go
@@ -2,6 +2,7 @@ package dials
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -51,7 +52,8 @@ func (f *fakeWatchingSource) send(ctx context.Context, val reflect.Value) {
 	f.cb(ctx, val.Convert(f.t.t))
 }
 
-func TestConfig(t *testing.T) {
+func TestConfigWithoutVerifier(t *testing.T) {
+	t.Parallel()
 	type testConfig struct {
 		Foo string
 	}
@@ -100,4 +102,211 @@ func TestConfig(t *testing.T) {
 	finalConf := <-d.Events()
 	assert.Equal(t, "foo", finalConf.(*testConfig).Foo)
 	assert.Equal(t, "foo", d.View().(*testConfig).Foo)
+}
+
+// failVerifier is a struct with a Verify() method that always fails with an error
+type failVerifier struct{}
+
+var errFailVerifier = errors.New("fail")
+
+func (failVerifier) Verify() error {
+	return errFailVerifier
+}
+
+var _ VerifiedConfig = (*failVerifier)(nil)
+
+func TestConfigWithFailVerifier(t *testing.T) {
+	t.Parallel()
+	type testConfig struct {
+		failVerifier
+		Foo string
+	}
+
+	type ptrifiedConfig struct {
+		Foo *string
+	}
+
+	base := testConfig{
+		Foo: "foo",
+	}
+	emptyConf := ptrifiedConfig{
+		Foo: nil,
+	}
+	// Push a new value, that should overlay on top of the base
+	foozleStr := "foozle"
+	foozleConfig := ptrifiedConfig{
+		Foo: &foozleStr,
+	}
+
+	// setup a cancelable context so the monitor goroutine gets shutdown.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := fakeWatchingSource{fakeSource: fakeSource{outVal: foozleConfig}}
+	_, err := Config(ctx, &base, &fakeSource{outVal: emptyConf}, &w)
+	if !errors.Is(err, errFailVerifier) {
+		t.Fatalf("unexpected error: got %s; expected %s", err, errFailVerifier)
+	}
+}
+
+// successVerifier is a struct with a Verify() method that always fails with an error
+type successVerifier struct{}
+
+func (successVerifier) Verify() error {
+	return nil
+}
+
+var _ VerifiedConfig = (*successVerifier)(nil)
+
+func TestConfigWithSuccessVerifier(t *testing.T) {
+	t.Parallel()
+	type testConfig struct {
+		successVerifier
+		Foo string
+	}
+
+	type ptrifiedConfig struct {
+		Foo *string
+	}
+
+	base := testConfig{
+		Foo: "foo",
+	}
+	emptyConf := ptrifiedConfig{
+		Foo: nil,
+	}
+	// Push a new value, that should overlay on top of the base
+	foozleStr := "foozle"
+	foozleConfig := ptrifiedConfig{
+		Foo: &foozleStr,
+	}
+
+	// setup a cancelable context so the monitor goroutine gets shutdown.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := fakeWatchingSource{fakeSource: fakeSource{outVal: foozleConfig}}
+	d, err := Config(ctx, &base, &fakeSource{outVal: emptyConf}, &w)
+	require.NoError(t, err)
+
+	// pull in the existing value and verify that it works as intended.
+	// overwrite our original "base" to verify deep-copying is doing its job.
+	d.Fill(&base)
+	assert.Equal(t, "foozle", base.Foo)
+
+	// Push a new value, that should overlay on top of the base
+	fimStr := "fim"
+	fimConfig := ptrifiedConfig{
+		Foo: &fimStr,
+	}
+	w.send(ctx, reflect.ValueOf(fimConfig))
+	c := <-d.Events()
+	assert.Equal(t, "fim", c.(*testConfig).Foo)
+	assert.Equal(t, "fim", d.View().(*testConfig).Foo)
+
+	// push another empty config
+	w.send(ctx, reflect.ValueOf(emptyConf))
+	finalConf := <-d.Events()
+	assert.Equal(t, "foo", finalConf.(*testConfig).Foo)
+	assert.Equal(t, "foo", d.View().(*testConfig).Foo)
+}
+
+// configurableVerifier is a struct with a Verify() method that fails depending
+// on the value of valid.
+type configurableVerifier struct {
+	Valid bool
+	Foo   string
+}
+
+func (c configurableVerifier) Verify() error {
+	if c.Valid {
+		return nil
+	}
+	return errFailVerifier
+}
+
+var _ VerifiedConfig = (*configurableVerifier)(nil)
+
+func TestConfigWithConfigureVerifier(t *testing.T) {
+	t.Parallel()
+	trueVal := true
+	falseVal := false
+
+	type ptrifiedConfig struct {
+		Valid *bool
+		Foo   *string
+	}
+
+	base := configurableVerifier{
+		Valid: true,
+		Foo:   "foo",
+	}
+	emptyConf := ptrifiedConfig{
+		Valid: nil,
+		Foo:   nil,
+	}
+	// Push a new value, that should overlay on top of the base
+	foozleStr := "foozle"
+	foozleConfig := ptrifiedConfig{
+		Valid: &trueVal,
+		Foo:   &foozleStr,
+	}
+
+	// setup a cancelable context so the monitor goroutine gets shutdown.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	params := Params{
+		OnWatchedError: func(ctx context.Context, err error, _, _ interface{}) { errCh <- err },
+	}
+
+	w := fakeWatchingSource{fakeSource: fakeSource{outVal: foozleConfig}}
+	d, err := params.Config(ctx, &base, &fakeSource{outVal: emptyConf}, &w)
+	require.NoError(t, err)
+
+	// pull in the existing value and verify that it works as intended.
+	// overwrite our original "base" to verify deep-copying is doing its job.
+	d.Fill(&base)
+	assert.Equal(t, "foozle", base.Foo)
+
+	// Push a new value, that should overlay on top of the base
+	fimStr := "fim"
+	fimConfig := ptrifiedConfig{
+		Foo: &fimStr,
+	}
+	w.send(ctx, reflect.ValueOf(fimConfig))
+	select {
+	case c := <-d.Events():
+		assert.Equal(t, "fim", c.(*configurableVerifier).Foo)
+		assert.Equal(t, "fim", d.View().(*configurableVerifier).Foo)
+	case err := <-errCh:
+		t.Errorf("unexpected error from monitor: %s", err)
+	}
+
+	// send a config with Valid set to false
+	invalidStr := "invalid"
+	invalidConfig := ptrifiedConfig{Valid: &falseVal, Foo: &invalidStr}
+	w.send(ctx, reflect.ValueOf(invalidConfig))
+	select {
+	case unexpectedConf := <-d.Events():
+		assert.Equal(t, "foo", unexpectedConf.(*configurableVerifier).Foo)
+		assert.Equal(t, "foo", d.View().(*configurableVerifier).Foo)
+		assert.False(t, unexpectedConf.(*configurableVerifier).Valid)
+		assert.False(t, d.View().(*configurableVerifier).Valid)
+	case err := <-errCh:
+		if !errors.Is(err, errFailVerifier) {
+			t.Errorf("unexpected error from verification failure: %s", err)
+		}
+	}
+
+	// push another empty config
+	w.send(ctx, reflect.ValueOf(emptyConf))
+	select {
+	case finalConf := <-d.Events():
+		assert.Equal(t, "foo", finalConf.(*configurableVerifier).Foo)
+		assert.Equal(t, "foo", d.View().(*configurableVerifier).Foo)
+	case err := <-errCh:
+		t.Errorf("unexpected error from monitor: %s", err)
+	}
 }

--- a/ez/ez_test.go
+++ b/ez/ez_test.go
@@ -2,14 +2,17 @@ package ez
 
 import (
 	"context"
+	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-type Config struct {
+type config struct {
 	// Path will contain the path to the config file and will be set by
 	// environment variable
 	Path string              `dials:"CONFIGPATH"`
@@ -20,13 +23,13 @@ type Config struct {
 
 // ConfigPath reflects where the path to config file is stored. Path field
 // will be populated from environment variable
-func (c *Config) ConfigPath() (string, bool) {
+func (c *config) ConfigPath() (string, bool) {
 	return c.Path, true
 }
 
 // TestYAMLConfigEnvFlag cannot run concurrently with other tests because of
 // environment manipulation.
-func TestYAMLConfigEnvFlag(t *testing.T) {
+func TestYAMLConfigEnvFlagWithValidConfig(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -34,12 +37,12 @@ func TestYAMLConfigEnvFlag(t *testing.T) {
 	require.NoError(t, envErr)
 	defer os.Unsetenv("CONFIGPATH")
 
-	c := &Config{}
+	c := &config{}
 	view, dialsErr := YAMLConfigEnvFlag(ctx, c)
 	require.NoError(t, dialsErr)
 
 	// Val1 and Val2 come from the config file and Path will be populated from env variable
-	expectedConfig := Config{
+	expectedConfig := config{
 		Path: "../testhelper/testconfig.yaml",
 		Val1: 456,
 		Val2: "hello-world",
@@ -49,6 +52,89 @@ func TestYAMLConfigEnvFlag(t *testing.T) {
 			"Jack":  {},
 		},
 	}
-	populatedConf := view.View().(*Config)
+	populatedConf := view.View().(*config)
 	assert.EqualValues(t, expectedConfig, *populatedConf)
+}
+
+type validatingConfig struct {
+	// Path will contain the path to the config file and will be set by
+	// environment variable
+	Path string              `dials:"CONFIGPATHFIM"`
+	Val1 int                 `dials:"Val1"`
+	Val2 string              `dials:"Val2"`
+	Set  map[string]struct{} `dials:"Set"`
+}
+
+// ConfigPath reflects where the path to config file is stored. Path field
+// will be populated from environment variable
+func (c *validatingConfig) ConfigPath() (string, bool) {
+	return c.Path, true
+}
+
+func (c *validatingConfig) Verify() error {
+	if c.Val1 > 200 {
+		return fmt.Errorf("val1 %d > 200", c.Val1)
+	}
+	return nil
+}
+
+func TestYAMLConfigEnvFlagWithValidatingConfig(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tmpFile, tmpErr := ioutil.TempFile("", "")
+	require.NoError(t, tmpErr)
+	tmpFile.Write([]byte("Val1: 789"))
+	require.NoError(t, tmpFile.Sync())
+	require.NoError(t, tmpFile.Close())
+	path := tmpFile.Name()
+	defer os.Remove(path)
+
+	c := &validatingConfig{Path: path}
+	view, dialsErr := YAMLConfigEnvFlag(ctx, c)
+	assert.NotNil(t, view)
+	require.EqualError(t, dialsErr, "failed to stack/verify config with file layered: val1 789 > 200")
+}
+
+func TestYAMLConfigEnvFlagWithValidatingConfigInitiallyValid(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tmpDir, tmpErr := ioutil.TempDir("", "")
+	require.NoError(t, tmpErr)
+	defer os.RemoveAll(tmpDir)
+	path := filepath.Join(tmpDir, "fim1.yaml")
+	require.NoError(t, ioutil.WriteFile(path, []byte("Val1: 189"), 0660))
+	defer os.Remove(path)
+
+	errCh := make(chan error)
+	errHandler := func(ctx context.Context, err error, oldConfig, newConfig interface{}) {
+		errCh <- err
+	}
+	c := &validatingConfig{Path: path}
+	view, dialsErr := YAMLConfigEnvFlag(ctx, c, WithOnWatchedError(errHandler), WithWatchingConfigFile(true))
+	require.NoError(t, dialsErr)
+	assert.NotNil(t, view)
+
+	expectedConfig := validatingConfig{
+		Path: path,
+		Val1: 189,
+		Val2: "",
+		Set:  map[string]struct{}{},
+	}
+	populatedConf := view.View().(*validatingConfig)
+	assert.EqualValues(t, expectedConfig, *populatedConf)
+
+	tmpPath2 := filepath.Join(tmpDir, "_tmp_fim1.yaml")
+	require.NoError(t, ioutil.WriteFile(tmpPath2, []byte("Val1: 201"), os.FileMode(0660)))
+
+	require.NoError(t, os.Rename(tmpPath2, path))
+
+	// Write a new version of the config
+	select {
+	case newcfg := <-view.Events():
+		t.Errorf("unexpected new version; should have failed verification: %+v", newcfg)
+	case err := <-errCh:
+		require.EqualError(t, err, "val1 201 > 200")
+	}
 }

--- a/sourcewrap/blank.go
+++ b/sourcewrap/blank.go
@@ -52,6 +52,7 @@ func (b *Blank) Watch(ctx context.Context,
 	}
 	b.t = t
 	b.cb = cb
+	b.watchCtx = ctx
 	return nil
 }
 


### PR DESCRIPTION
When using a watching source, it's currently possible to end up with an invalid configuration, and there's no way to prevent that from being extracted in everything touching the config `View()` method.

This PR adds a new `VerifiedConfig` interface to the top-level package and moves the `Config()` function to a `Params` struct that contains one field (for now). That single field is a callback to execute upon verification (or stacking) failure.

Additionally, this fixes a segfault when using the blank source in watching mode because it failed to store the context it was passed. (this was uncovered while updating the `ez` package to take advantage of the new mechanism)