### PR TITLE
dials: Add context arg to Value() on Source

### DIFF
--- a/dials_test.go
+++ b/dials_test.go
@@ -32,7 +32,7 @@ type fakeSource struct {
 	outVal interface{}
 }
 
-func (f *fakeSource) Value(t *Type) (reflect.Value, error) {
+func (f *fakeSource) Value(_ context.Context, t *Type) (reflect.Value, error) {
 	return reflect.ValueOf(f.outVal).Convert(t.t), nil
 }
 

--- a/env/env.go
+++ b/env/env.go
@@ -1,6 +1,7 @@
 package env
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"reflect"
@@ -20,6 +21,8 @@ type Source struct {
 	Prefix string
 }
 
+var _ dials.Source = (*Source)(nil)
+
 // Value fills in the user-provided config struct using environment variables.
 // It looks up the environment variable to read into a given struct field by
 // using that field's `dialsenv` struct tag if present, then its `dials` tag if
@@ -27,7 +30,7 @@ type Source struct {
 // assumes the name is in Go-style camelCase (e.g., "JSONFilePath") and converts
 // it to UPPER_SNAKE_CASE. (The casing of `dialsenv` and `dials` tags is left
 // unchanged.)
-func (e *Source) Value(t *dials.Type) (reflect.Value, error) {
+func (e *Source) Value(_ context.Context, t *dials.Type) (reflect.Value, error) {
 	// flatten the nested fields
 	flattenMangler := transform.NewFlattenMangler(common.DialsTagName, caseconversion.EncodeUpperCamelCase, caseconversion.EncodeUpperCamelCase)
 	// reformat the tags so they are SCREAMING_SNAKE_CASE

--- a/file/file.go
+++ b/file/file.go
@@ -43,6 +43,8 @@ type Source struct {
 	hmacMu         sync.Mutex
 }
 
+var _ dials.Source = (*Source)(nil)
+
 func (s *Source) initKey() error {
 	s.hmacMu.Lock()
 	defer s.hmacMu.Unlock()
@@ -87,7 +89,7 @@ func (d *unchangedCSumErr) Error() string {
 }
 
 // Value opens the file and passes it to the Decoder.
-func (s *Source) Value(t *dials.Type) (reflect.Value, error) {
+func (s *Source) Value(_ context.Context, t *dials.Type) (reflect.Value, error) {
 	f, err := os.Open(s.path)
 	if err != nil {
 		return reflect.Value{}, err
@@ -179,6 +181,9 @@ type WatchingSource struct {
 	watcher      *fsnotify.Watcher
 	logger       logWrapper
 }
+
+var _ dials.Source = (*WatchingSource)(nil)
+var _ dials.Watcher = (*WatchingSource)(nil)
 
 // Watch Sets up an fsnotify Watcher and starts a background goroutine for watching changes.
 func (ws *WatchingSource) Watch(
@@ -292,7 +297,7 @@ MAINLOOP:
 			return
 		}
 
-		newVal, parseErr := ws.Value(t)
+		newVal, parseErr := ws.Value(ctx, t)
 
 		configExists := !os.IsNotExist(parseErr)
 		if !configExists {

--- a/flag/flag.go
+++ b/flag/flag.go
@@ -1,6 +1,7 @@
 package flag
 
 import (
+	"context"
 	"encoding"
 	"flag"
 	"fmt"
@@ -325,7 +326,7 @@ func (s *Set) registerFlags(tmpl reflect.Value, ptyp reflect.Type) error {
 // struct tag if present, then its `dials` tag if present, and finally its name.
 // If the struct has nested fields, Value will flatten the fields so flags can
 // be defined for nested fields.
-func (s *Set) Value(t *dials.Type) (reflect.Value, error) {
+func (s *Set) Value(_ context.Context, t *dials.Type) (reflect.Value, error) {
 	// Check whether we've gone through the exercise of parsing flags yet
 	// (and types are compatible).
 	if s.ptrType != nil {

--- a/pflag/pflag.go
+++ b/pflag/pflag.go
@@ -1,6 +1,7 @@
 package pflag
 
 import (
+	"context"
 	"encoding"
 	"fmt"
 	"os"
@@ -321,7 +322,7 @@ func (s *Set) registerFlags(tmpl reflect.Value, ptyp reflect.Type) error {
 // struct tag if present, then its `dials` tag if present, and finally its name.
 // If the struct has nested fields, Value will flatten the fields so flags can
 // be defined for nested fields.
-func (s *Set) Value(t *dials.Type) (reflect.Value, error) {
+func (s *Set) Value(_ context.Context, t *dials.Type) (reflect.Value, error) {
 	// Check whether we've gone through the exercise of parsing flags yet
 	// (and types are compatible).
 	if s.ptrType != nil {

--- a/sourcewrap/blank.go
+++ b/sourcewrap/blank.go
@@ -33,10 +33,10 @@ func (b *Blank) getInner() dials.Source {
 
 // Value implements the dials.Source interface, returning either a zero-value
 // for the type it's passed, or delegating to the wrapped source (if present).
-func (b *Blank) Value(t *dials.Type) (reflect.Value, error) {
+func (b *Blank) Value(ctx context.Context, t *dials.Type) (reflect.Value, error) {
 	inner := b.getInner()
 	if inner != nil {
-		return inner.Value(t)
+		return inner.Value(ctx, t)
 	}
 	return reflect.New(t.Type()), nil
 }
@@ -80,8 +80,7 @@ func (b *Blank) SetSource(ctx context.Context, s dials.Source) error {
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	// TODO: this seems wrong, Value should take a context as well.
-	v, err := s.Value(b.t)
+	v, err := s.Value(ctx, b.t)
 	if err != nil {
 		return &wrappedErr{prefix: "initial call to Value failed: ", err: err}
 	}

--- a/sourcewrap/blank_test.go
+++ b/sourcewrap/blank_test.go
@@ -16,7 +16,7 @@ type trivalCountingSource struct {
 	callCount uint32
 }
 
-func (t *trivalCountingSource) Value(typ *dials.Type) (reflect.Value, error) {
+func (t *trivalCountingSource) Value(_ context.Context, typ *dials.Type) (reflect.Value, error) {
 	t.callCount++
 	return reflect.New(typ.Type()), nil
 }
@@ -28,7 +28,7 @@ type trivalErroringSource struct {
 	err       error
 }
 
-func (t *trivalErroringSource) Value(typ *dials.Type) (reflect.Value, error) {
+func (t *trivalErroringSource) Value(_ context.Context, typ *dials.Type) (reflect.Value, error) {
 	t.callCount++
 	return reflect.Value{}, t.err
 }
@@ -49,7 +49,7 @@ func (t *trivalCountingWatchingSource) Watch(ctx context.Context, typ *dials.Typ
 	return nil
 }
 
-func (t *trivalCountingWatchingSource) Value(typ *dials.Type) (reflect.Value, error) {
+func (t *trivalCountingWatchingSource) Value(_ context.Context, typ *dials.Type) (reflect.Value, error) {
 	t.callCount++
 	return reflect.New(typ.Type()), nil
 }
@@ -69,7 +69,7 @@ func (t *trivalErroringWatchingSource) Watch(ctx context.Context, typ *dials.Typ
 	return t.err
 }
 
-func (t *trivalErroringWatchingSource) Value(typ *dials.Type) (reflect.Value, error) {
+func (t *trivalErroringWatchingSource) Value(_ context.Context, typ *dials.Type) (reflect.Value, error) {
 	t.callCount++
 	return reflect.New(typ.Type()), nil
 }

--- a/sourcewrap/transforming_source.go
+++ b/sourcewrap/transforming_source.go
@@ -68,7 +68,7 @@ type transformingSourceNoWatch struct {
 	src      dials.Source
 }
 
-func (t *transformingSourceNoWatch) Value(typ *dials.Type) (reflect.Value, error) {
+func (t *transformingSourceNoWatch) Value(ctx context.Context, typ *dials.Type) (reflect.Value, error) {
 	tfm := transform.NewTransformer(typ.Type(), t.manglers...)
 	transformedVal, transformErr := tfm.TranslateType()
 	if transformErr != nil {
@@ -76,7 +76,7 @@ func (t *transformingSourceNoWatch) Value(typ *dials.Type) (reflect.Value, error
 	}
 	innerTyp := dials.NewType(transformedVal)
 
-	srcVal, srcErr := t.src.Value(innerTyp)
+	srcVal, srcErr := t.src.Value(ctx, innerTyp)
 	if srcErr != nil {
 		return reflect.Value{}, &wrappedErr{prefix: "inner source failed: ", err: srcErr}
 	}

--- a/static/static.go
+++ b/static/static.go
@@ -1,6 +1,7 @@
 package static
 
 import (
+	"context"
 	"reflect"
 	"strings"
 
@@ -13,8 +14,10 @@ type StringSource struct {
 	Decoder dials.Decoder
 }
 
+var _ dials.Source = (*StringSource)(nil)
+
 // Value ...
-func (s *StringSource) Value(t *dials.Type) (reflect.Value, error) {
+func (s *StringSource) Value(_ context.Context, t *dials.Type) (reflect.Value, error) {
 	reader := strings.NewReader(s.Data)
 	return s.Decoder.Decode(reader, t)
 }


### PR DESCRIPTION
Some `Source` implementations will need to make external requests, and as such should have contexts passed to their `Value()` methods.

Add a `context.Context` argument to the `Value` method on the `Source` interface and update `Config()` to call it with a context that's cancelled on function exit (document this behavior).

This PR fixes the main blocker for `Source` interface stabilization. (a future PR will make some adjustments to the `Watcher` interface)