### PR TITLE
dials: Update Watcher Interface to use an interface arg

### DIFF
--- a/dials.go
+++ b/dials.go
@@ -46,8 +46,8 @@ type Params struct {
 // consuming from the channel returned by `Events()`.
 func (p Params) Config(ctx context.Context, t interface{}, sources ...Source) (*Dials, error) {
 
-	watcherChan := make(chan *watchTab)
-	computed := make([]sourceValue, 0, len(sources))
+	watcherChan := make(chan watchStatusUpdate)
+	computed := make([]sourceValue, len(sources))
 
 	typeOfT := reflect.TypeOf(t)
 	if typeOfT.Kind() != reflect.Ptr {
@@ -61,26 +61,24 @@ func (p Params) Config(ctx context.Context, t interface{}, sources ...Source) (*
 
 	typeInstance := &Type{ptrify.Pointerify(typeOfT.Elem(), tVal.Elem())}
 	someoneWatching := false
-	for _, source := range sources {
+	for i, source := range sources {
 		s := source
 
 		v, err := source.Value(valueCtx, typeInstance)
 		if err != nil {
 			return nil, err
 		}
-		computed = append(computed, sourceValue{
-			source: s,
-			value:  v,
-		})
+		computed[i] = sourceValue{
+			source:   s,
+			value:    v,
+			watching: false,
+		}
 
 		if w, ok := source.(Watcher); ok {
 			someoneWatching = true
-			err = w.Watch(ctx, typeInstance, func(ctx context.Context, v reflect.Value) {
-				select {
-				case <-ctx.Done():
-				case watcherChan <- &watchTab{source: s, value: v}:
-				}
-			})
+			computed[i].watching = true
+			wa := watchArgs{c: watcherChan, s: source}
+			err = w.Watch(ctx, typeInstance, &wa)
 			if err != nil {
 				return nil, err
 			}
@@ -106,6 +104,7 @@ func (p Params) Config(ctx context.Context, t interface{}, sources ...Source) (*
 		}
 	}
 
+	// After this point, computed is owned by the monitor goroutine
 	if someoneWatching {
 		go d.monitor(ctx, tVal.Interface(), computed, watcherChan)
 	}
@@ -144,9 +143,41 @@ type Decoder interface {
 	Decode(io.Reader, *Type) (reflect.Value, error)
 }
 
-type watchTab struct {
+type valueUpdate struct {
 	source Source
 	value  reflect.Value
+}
+
+func (valueUpdate) isStatusReport() {}
+
+type watchStatusUpdate interface {
+	isStatusReport()
+}
+
+type watchArgs struct {
+	s Source
+	c chan watchStatusUpdate
+}
+
+// NewValue reports a new value. Returns an error if the internal
+// reporting channel is full and the context expires/is-canceled.
+func (w *watchArgs) NewValue(ctx context.Context, val reflect.Value) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case w.c <- &valueUpdate{source: w.s, value: val}:
+		return nil
+	}
+}
+
+// WatchArgs provides methods for a Watcher implementation to update the state
+// of a Dials instance.
+type WatchArgs interface {
+	// NewValue reports a new value. The base implementation returns an
+	// error if the internal reporting channel is full and the context
+	// expires/is-canceled, however, wrapping implementations are free to
+	// return any other error as appropriate.
+	NewValue(ctx context.Context, val reflect.Value) error
 }
 
 // Watcher should be implemented by Sources that allow their configuration to be
@@ -155,7 +186,7 @@ type Watcher interface {
 	// Watch will be called in the primary goroutine calling Config(). If
 	// Watcher implementations need a persistent goroutine, they should
 	// spawn it themselves.
-	Watch(context.Context, *Type, func(context.Context, reflect.Value)) error
+	Watch(context.Context, *Type, WatchArgs) error
 }
 
 // VerifiedConfig implements the Verify method, allowing Dials to execute the
@@ -205,47 +236,61 @@ func (d *Dials) Fill(blankConfig interface{}) {
 	bVal.Elem().Set(currentVal.Elem())
 }
 
+func (d *Dials) updateSourceValue(
+	ctx context.Context,
+	t interface{},
+	sourceValues []sourceValue,
+	watchTab *valueUpdate,
+) {
+	for i, sv := range sourceValues {
+		if watchTab.source == sv.source {
+			sourceValues[i].value = watchTab.value
+			break
+		}
+	}
+	newInterface, stackErr := compose(t, sourceValues)
+	if stackErr != nil {
+		if d.params.OnWatchedError != nil {
+			d.params.OnWatchedError(
+				ctx, stackErr, d.value.Load(), newInterface)
+		}
+		return
+	}
+
+	// Verify that the configuration is valid if a Verify() method is present.
+	if vf, ok := newInterface.(VerifiedConfig); ok {
+		if vfErr := vf.Verify(); vfErr != nil {
+			if d.params.OnWatchedError != nil {
+				d.params.OnWatchedError(
+					ctx, vfErr, d.value.Load(), newInterface)
+			}
+			return
+		}
+	}
+
+	d.value.Store(newInterface)
+	select {
+	case d.updatesChan <- newInterface:
+	default:
+	}
+}
+
 func (d *Dials) monitor(
 	ctx context.Context,
 	t interface{},
 	sourceValues []sourceValue,
-	watcherChan chan *watchTab,
+	watcherChan chan watchStatusUpdate,
 ) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case watchTab := <-watcherChan:
-			for i, sv := range sourceValues {
-				if watchTab.source == sv.source {
-					sourceValues[i].value = watchTab.value
-					break
-				}
-			}
-			newInterface, stackErr := compose(t, sourceValues)
-			if stackErr != nil {
-				if d.params.OnWatchedError != nil {
-					d.params.OnWatchedError(
-						ctx, stackErr, d.value.Load(), newInterface)
-				}
-				continue
-			}
-
-			// Verify that the configuration is valid if a Verify() method is present.
-			if vf, ok := newInterface.(VerifiedConfig); ok {
-				if vfErr := vf.Verify(); vfErr != nil {
-					if d.params.OnWatchedError != nil {
-						d.params.OnWatchedError(
-							ctx, vfErr, d.value.Load(), newInterface)
-					}
-					continue
-				}
-			}
-
-			d.value.Store(newInterface)
-			select {
-			case d.updatesChan <- newInterface:
+			switch v := watchTab.(type) {
+			case *valueUpdate:
+				d.updateSourceValue(ctx, t, sourceValues, v)
 			default:
+				panic(fmt.Errorf("unexpected type %[1]T: %+[1]v", watchTab))
 			}
 		}
 	}
@@ -272,8 +317,9 @@ func compose(t interface{}, sources []sourceValue) (interface{}, error) {
 }
 
 type sourceValue struct {
-	source Source
-	value  reflect.Value
+	source   Source
+	value    reflect.Value
+	watching bool
 }
 
 // Type is a wrapper for a reflect.Type.

--- a/dials.go
+++ b/dials.go
@@ -159,9 +159,9 @@ type watchArgs struct {
 	c chan watchStatusUpdate
 }
 
-// NewValue reports a new value. Returns an error if the internal
+// ReportNewValue reports a new value. Returns an error if the internal
 // reporting channel is full and the context expires/is-canceled.
-func (w *watchArgs) NewValue(ctx context.Context, val reflect.Value) error {
+func (w *watchArgs) ReportNewValue(ctx context.Context, val reflect.Value) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -173,11 +173,11 @@ func (w *watchArgs) NewValue(ctx context.Context, val reflect.Value) error {
 // WatchArgs provides methods for a Watcher implementation to update the state
 // of a Dials instance.
 type WatchArgs interface {
-	// NewValue reports a new value. The base implementation returns an
+	// ReportNewValue reports a new value. The base implementation returns an
 	// error if the internal reporting channel is full and the context
 	// expires/is-canceled, however, wrapping implementations are free to
 	// return any other error as appropriate.
-	NewValue(ctx context.Context, val reflect.Value) error
+	ReportNewValue(ctx context.Context, val reflect.Value) error
 }
 
 // Watcher should be implemented by Sources that allow their configuration to be

--- a/dials_test.go
+++ b/dials_test.go
@@ -49,7 +49,7 @@ func (f *fakeWatchingSource) Watch(_ context.Context, t *Type, args WatchArgs) e
 }
 
 func (f *fakeWatchingSource) send(ctx context.Context, val reflect.Value) {
-	f.args.NewValue(ctx, val.Convert(f.t.t))
+	f.args.ReportNewValue(ctx, val.Convert(f.t.t))
 }
 
 func TestConfigWithoutVerifier(t *testing.T) {

--- a/dials_test.go
+++ b/dials_test.go
@@ -38,18 +38,18 @@ func (f *fakeSource) Value(_ context.Context, t *Type) (reflect.Value, error) {
 
 type fakeWatchingSource struct {
 	fakeSource
-	t  *Type
-	cb func(context.Context, reflect.Value)
+	t    *Type
+	args WatchArgs
 }
 
-func (f *fakeWatchingSource) Watch(_ context.Context, t *Type, cb func(context.Context, reflect.Value)) error {
-	f.cb = cb
+func (f *fakeWatchingSource) Watch(_ context.Context, t *Type, args WatchArgs) error {
+	f.args = args
 	f.t = t
 	return nil
 }
 
 func (f *fakeWatchingSource) send(ctx context.Context, val reflect.Value) {
-	f.cb(ctx, val.Convert(f.t.t))
+	f.args.NewValue(ctx, val.Convert(f.t.t))
 }
 
 func TestConfigWithoutVerifier(t *testing.T) {

--- a/file/file.go
+++ b/file/file.go
@@ -337,7 +337,7 @@ MAINLOOP:
 			continue
 		}
 
-		args.NewValue(ctx, newVal)
+		args.ReportNewValue(ctx, newVal)
 	}
 
 }

--- a/file/file.go
+++ b/file/file.go
@@ -189,7 +189,7 @@ var _ dials.Watcher = (*WatchingSource)(nil)
 func (ws *WatchingSource) Watch(
 	ctx context.Context,
 	t *dials.Type,
-	callback func(context.Context, reflect.Value)) error {
+	args dials.WatchArgs) error {
 	cleanedPath := filepath.Clean(ws.path)
 
 	// remove one-level of symlinks
@@ -220,7 +220,7 @@ func (ws *WatchingSource) Watch(
 	}
 
 	ws.WG.Add(1)
-	go ws.watchLoop(ctx, t, cleanedPath, resolvedCfgPath, callback)
+	go ws.watchLoop(ctx, t, cleanedPath, resolvedCfgPath, args)
 	return nil
 }
 
@@ -251,7 +251,7 @@ func (ws *WatchingSource) watchLoop(
 	ctx context.Context,
 	t *dials.Type,
 	cleanedPath, resolvedCfgPath string,
-	callback func(context.Context, reflect.Value),
+	args dials.WatchArgs,
 ) {
 	defer ws.WG.Done()
 	defer signal.Stop(ws.Reload)
@@ -337,7 +337,7 @@ MAINLOOP:
 			continue
 		}
 
-		callback(ctx, newVal)
+		args.NewValue(ctx, newVal)
 	}
 
 }

--- a/sourcewrap/blank.go
+++ b/sourcewrap/blank.go
@@ -100,7 +100,7 @@ func (b *Blank) SetSource(ctx context.Context, s dials.Source) error {
 		return &wrappedErr{prefix: "initial call to Value failed: ", err: err}
 	}
 	b.inner = s
-	if newValErr := b.wa.NewValue(ctx, v); newValErr != nil {
+	if newValErr := b.wa.ReportNewValue(ctx, v); newValErr != nil {
 		return fmt.Errorf("failed to propagate change: %w", newValErr)
 	}
 

--- a/sourcewrap/blank_test.go
+++ b/sourcewrap/blank_test.go
@@ -38,13 +38,15 @@ func (t *trivalErroringSource) Value(_ context.Context, typ *dials.Type) (reflec
 type trivalCountingWatchingSource struct {
 	callCount   uint32
 	watchcalled bool
-	cb          func(context.Context, reflect.Value)
+	args        dials.WatchArgs
 	typ         *dials.Type
 }
 
-func (t *trivalCountingWatchingSource) Watch(ctx context.Context, typ *dials.Type, cb func(context.Context, reflect.Value)) error {
+var _ dials.Watcher = (*trivalCountingWatchingSource)(nil)
+
+func (t *trivalCountingWatchingSource) Watch(ctx context.Context, typ *dials.Type, args dials.WatchArgs) error {
 	t.watchcalled = true
-	t.cb = cb
+	t.args = args
 	t.typ = typ
 	return nil
 }
@@ -55,7 +57,7 @@ func (t *trivalCountingWatchingSource) Value(_ context.Context, typ *dials.Type)
 }
 
 func (t *trivalCountingWatchingSource) poke(ctx context.Context) {
-	t.cb(ctx, reflect.New(t.typ.Type()))
+	t.args.NewValue(ctx, reflect.New(t.typ.Type()))
 }
 
 type trivalErroringWatchingSource struct {
@@ -64,7 +66,9 @@ type trivalErroringWatchingSource struct {
 	err         error
 }
 
-func (t *trivalErroringWatchingSource) Watch(ctx context.Context, typ *dials.Type, cb func(context.Context, reflect.Value)) error {
+var _ dials.Watcher = (*trivalErroringWatchingSource)(nil)
+
+func (t *trivalErroringWatchingSource) Watch(ctx context.Context, typ *dials.Type, args dials.WatchArgs) error {
 	t.watchcalled = true
 	return t.err
 }

--- a/sourcewrap/blank_test.go
+++ b/sourcewrap/blank_test.go
@@ -57,7 +57,7 @@ func (t *trivalCountingWatchingSource) Value(_ context.Context, typ *dials.Type)
 }
 
 func (t *trivalCountingWatchingSource) poke(ctx context.Context) {
-	t.args.NewValue(ctx, reflect.New(t.typ.Type()))
+	t.args.ReportNewValue(ctx, reflect.New(t.typ.Type()))
 }
 
 type trivalErroringWatchingSource struct {


### PR DESCRIPTION
Create a WatchArgs interface for the third argument to Watch() and a base implementation.

Convert the existing implementations of `Watcher` to support the new interface definition.

Tighten the contract on the `Blank` source while we're in there.