### PR TITLE
Improve Verification in EZ

### DIFF
--- a/dials.go
+++ b/dials.go
@@ -26,12 +26,11 @@ type Params struct {
 	OnWatchedError WatchedErrorHandler
 
 	// SkipInitialVerification skips the initial call to `Verify()` on any
-	// configurations that implement the `VerifiedConfig` interface.  In cases
-	// where Watching sources are depended upon to provide values that will
-	// successfully verify on the very first access, one should set this to
-	// `true`.  `sourcewrap.Blank` is one such example where values are not
-	// initially available and would not be able to be considered for initial
-	// verification.
+	// configurations that implement the `VerifiedConfig` interface.
+	//
+	// In cases where later updates from Watching sources are depended upon to
+	// provide a configuration that will be allowed by Verify(), one should set
+	// this to true.  See `sourcewrap.Blank` for more details.
 	SkipInitialVerification bool
 }
 

--- a/dials.go
+++ b/dials.go
@@ -24,6 +24,13 @@ type Params struct {
 	//  - a Verify() method fails after re-stacking when a new version is
 	//    provided by a watching source
 	OnWatchedError WatchedErrorHandler
+
+	// SkipInitialVerification doesn't run the initial verification that would
+	// generally happen while calling `Config`.  This is useful when there are
+	// `Blank` sources that have dependent values in other sources and we don't
+	// expect to have a fully valid config until the Blank is appropriately
+	// replaced.  See the `ez` package.
+	SkipInitialVerification bool
 }
 
 // Config populates the passed in config struct by reading the values from the
@@ -98,7 +105,7 @@ func (p Params) Config(ctx context.Context, t interface{}, sources ...Source) (*
 	d.value.Store(newValue)
 
 	// Verify that the configuration is valid if a Verify() method is present.
-	if vf, ok := newValue.(VerifiedConfig); ok {
+	if vf, ok := newValue.(VerifiedConfig); ok && !p.SkipInitialVerification {
 		if vfErr := vf.Verify(); vfErr != nil {
 			return nil, fmt.Errorf("Initial configuration verification failed: %w", vfErr)
 		}

--- a/dials.go
+++ b/dials.go
@@ -25,11 +25,13 @@ type Params struct {
 	//    provided by a watching source
 	OnWatchedError WatchedErrorHandler
 
-	// SkipInitialVerification doesn't run the initial verification that would
-	// generally happen while calling `Config`.  This is useful when there are
-	// `Blank` sources that have dependent values in other sources and we don't
-	// expect to have a fully valid config until the Blank is appropriately
-	// replaced.  See the `ez` package.
+	// SkipInitialVerification skips the initial call to `Verify()` on any
+	// configurations that implement the `VerifiedConfig` interface.  In cases
+	// where Watching sources are depended upon to provide values that will
+	// successfully verify on the very first access, one should set this to
+	// `true`.  `sourcewrap.Blank` is one such example where values are not
+	// initially available and would not be able to be considered for initial
+	// verification.
 	SkipInitialVerification bool
 }
 

--- a/ez/ez.go
+++ b/ez/ez.go
@@ -157,6 +157,9 @@ func ConfigFileEnvFlag(ctx context.Context, cfg ConfigWithConfigPath, df Decoder
 				}
 			}
 		},
+		// Skip the initial verification to allow files to provide values that
+		// will be considered during verification.  If a file source isn't
+		// provided we'll appropriately call Verify before returning.
 		SkipInitialVerification: true,
 	}
 

--- a/ez/ez.go
+++ b/ez/ez.go
@@ -168,9 +168,9 @@ func ConfigFileEnvFlag(ctx context.Context, cfg ConfigWithConfigPath, df Decoder
 	basecfg := d.View().(ConfigWithConfigPath)
 	cfgPath, filepathSet := basecfg.ConfigPath()
 	if !filepathSet {
-		// Since we disabled initial verification earlier, let's verify
-		// specifically given that, without a config file, there's no
-		// opportunity for other values to be introduced into the configuration.
+		// Since we disabled initial verification earlier verify the config explicitly.
+		// Without a config file, the sources never get re-stacked, so the `Verify()`
+		// method is never run by `dials.Config`.
 		if vf, ok := basecfg.(dials.VerifiedConfig); ok {
 			if vfErr := vf.Verify(); vfErr != nil {
 				return nil, fmt.Errorf("Initial configuration verification failed: %w", vfErr)

--- a/ez/ez_test.go
+++ b/ez/ez_test.go
@@ -72,6 +72,12 @@ func (c *validatingConfig) ConfigPath() (string, bool) {
 }
 
 func (c *validatingConfig) Verify() error {
+	// check for the zero value, so we can distinguish between unset and set to
+	// something bad.
+	if c.Val1 == 0 {
+		return fmt.Errorf("val1 unset")
+	}
+
 	if c.Val1 > 200 {
 		return fmt.Errorf("val1 %d > 200", c.Val1)
 	}
@@ -91,8 +97,8 @@ func TestYAMLConfigEnvFlagWithValidatingConfig(t *testing.T) {
 	defer os.Remove(path)
 
 	c := &validatingConfig{Path: path}
-	view, dialsErr := YAMLConfigEnvFlag(ctx, c)
-	assert.NotNil(t, view)
+	d, dialsErr := YAMLConfigEnvFlag(ctx, c)
+	assert.NotNil(t, d)
 	require.EqualError(t, dialsErr, "failed to stack/verify config with file layered: val1 789 > 200")
 }
 

--- a/sourcewrap/blank.go
+++ b/sourcewrap/blank.go
@@ -9,12 +9,24 @@ import (
 	"github.com/vimeo/dials"
 )
 
-// Blank operates as a blank source in its default state, but has a SetSource
-// method for setting the source later, it then uses the dials.Watcher
-// interface to update the View it's inserted into.
+// Blank operates as a blank Source in its default state. It provides a
+// SetSource method for updating the inner Source later and uses the
+// dials.Watcher interface to update the View it's inserted into.
 //
 // Blanks cannot be reused as they have to be aware of parameters of a
 // particular View.
+//
+// Note that when using this, consider setting `SkipInitialVerification` on
+// `dials.Params` to `true` if any data from Blank-wrapped sources is considered
+// critical by the `Verify()` method provided by a configuration implementing
+// `dials.VerifiedConfig`.
+//
+// For instance, consider when one's configuration implements
+// `dials.VerifiedConfig` and should receive data from two Sources, one being
+// wrapped by `sourcewrap.Blank`. When `SkipInitialVerification` is `false`,
+// `params.Config` will call `Verify()` before the Blank-wrapped source has a
+// chance to have its inner Source updated. Therefore, this initial call to
+// `Verify()` will only have data provided by the non-Blank-wrapped source.
 type Blank struct {
 	inner dials.Source
 	mu    sync.Mutex


### PR DESCRIPTION
It's common that we would have some required values that might only be
set in the config file.  Previously when using the EZ package, the
`VerifiedConfig` interface was running on the initial stacking before
the config file had a chance to load values in to the overall values.
This allows us to skip the initial verification and wait until the file
is (optionally) considered before running verification.