### PR TITLE
Add File Key Casing to ez

### DIFF
--- a/ez/ez.go
+++ b/ez/ez.go
@@ -26,10 +26,13 @@ type Option func(*dialsOptions)
 
 type dialsOptions struct {
 	watch          bool
-	flagConfig     *flag.NameConfig
-	autoSetToSlice bool
-	flagSubstitute dials.Source
 	onWatchedError dials.WatchedErrorHandler
+
+	flagConfig     *flag.NameConfig
+	flagSubstitute dials.Source
+
+	autoSetToSlice bool
+
 	fileKeyDecoder caseconversion.DecodeCasingFunc
 	fileKeyEncoder caseconversion.EncodeCasingFunc
 }
@@ -37,12 +40,15 @@ type dialsOptions struct {
 func getDefaultOption() *dialsOptions {
 	return &dialsOptions{
 		watch:          false,
-		flagConfig:     flag.DefaultFlagNameConfig(),
-		autoSetToSlice: true,
-		flagSubstitute: nil,
 		onWatchedError: nil,
-		fileKeyEncoder: nil,
+
+		flagConfig:     flag.DefaultFlagNameConfig(),
+		flagSubstitute: nil,
+
+		autoSetToSlice: true,
+
 		fileKeyDecoder: nil,
+		fileKeyEncoder: nil,
 	}
 }
 

--- a/tagformat/reformat_tags.go
+++ b/tagformat/reformat_tags.go
@@ -33,11 +33,16 @@ func NewTagReformattingMangler(tagName string,
 // Mangle is called for every field in a struct, and returns the value
 // unchanged other than replacing the specified tag.
 func (k *TagReformattingMangler) Mangle(sf reflect.StructField) ([]reflect.StructField, error) {
-	dialsVal := sf.Tag.Get(k.tag)
-	if dialsVal == "" {
-		return []reflect.StructField{sf}, nil
+	nameVal := sf.Tag.Get(k.tag)
+	dcf := k.decodeCasingFunc
+	if nameVal == "" {
+		// There was no name defined, so just fall back to the field name and
+		// force the decoder to use Go conventions.
+		nameVal = sf.Name
+		dcf = caseconversion.DecodeGoCamelCase
 	}
-	splitTagVal, err := k.decodeCasingFunc(dialsVal)
+
+	splitTagVal, err := dcf(nameVal)
 	if err != nil {
 		return nil, err
 	}

--- a/tagformat/reformat_tags_test.go
+++ b/tagformat/reformat_tags_test.go
@@ -23,10 +23,12 @@ func TestReformatdialsTag(t *testing.T) {
 }
 
 func TestNoTag(t *testing.T) {
-	trm := NewTagReformattingMangler(common.DialsTagName, caseconversion.DecodeLowerCamelCase, caseconversion.EncodeLowerSnakeCase)
-	sf := reflect.StructField{}
+	trm := NewTagReformattingMangler(common.DialsTagName, caseconversion.DecodeGoCamelCase, caseconversion.EncodeLowerSnakeCase)
+	sf := reflect.StructField{
+		Name: "FieldName",
+	}
 	newSFSlice, err := trm.Mangle(sf)
 	require.Len(t, newSFSlice, 1)
 	require.NoError(t, err)
-	assert.Equal(t, "", string(newSFSlice[0].Tag))
+	assert.Equal(t, `dials:"field_name"`, string(newSFSlice[0].Tag))
 }

--- a/testhelper/testconfig.yaml
+++ b/testhelper/testconfig.yaml
@@ -4,3 +4,8 @@ Set:
   - Keith
   - Gary
   - Jack
+beatles-members:
+  John: guitar
+  Paul: bass
+  George: guitar
+  Ringo: drums


### PR DESCRIPTION
To avoid having to specify `dials` tags just to get consistent
transformations from Go-case to another strategy, provide a way for the
user to provide an additional mangler to alter the casing.