### PR TITLE
Complex Parsing

### DIFF
--- a/parse/complex.go
+++ b/parse/complex.go
@@ -1,3 +1,5 @@
+// +build !go1.15
+
 package parse
 
 import (

--- a/parse/complex_go115.go
+++ b/parse/complex_go115.go
@@ -1,0 +1,18 @@
+// +build go1.15
+
+package parse
+
+import (
+	"strconv"
+)
+
+// Complex64 delegates to strconv.ParseComplex for go >= 1.15.
+func Complex64(s string) (complex64, error) {
+	c, err := strconv.ParseComplex(s, 64)
+	return complex64(c), err
+}
+
+// Complex128 delegates to strconv.ParseComplex for go >= 1.15.
+func Complex128(s string) (complex128, error) {
+	return strconv.ParseComplex(s, 128)
+}

--- a/parse/complex_test.go
+++ b/parse/complex_test.go
@@ -1,3 +1,5 @@
+// +build !go1.15
+
 package parse
 
 import (

--- a/transform/string_casting_mangler_test.go
+++ b/transform/string_casting_mangler_test.go
@@ -131,14 +131,14 @@ func TestStringCastingManglerUnmangle(t *testing.T) {
 		},
 		"complex64": {
 			StructFieldType: reflect.TypeOf(complex64(10 + 3i)),
-			StringValue:     "10 + 3i",
+			StringValue:     "10+3i",
 			AssertFunc: func(i interface{}) {
 				assert.Equal(t, complex64(10+3i), *(i.(*complex64)))
 			},
 		},
 		"complex128": {
 			StructFieldType: reflect.TypeOf(complex128(10 + 3i)),
-			StringValue:     "10 + 3i",
+			StringValue:     "10+3i",
 			AssertFunc: func(i interface{}) {
 				assert.Equal(t, complex128(10+3i), *(i.(*complex128)))
 			},
@@ -193,7 +193,7 @@ func TestStringCastingManglerUnmangle(t *testing.T) {
 		},
 		"complex128_slice": {
 			StructFieldType: reflect.TypeOf([]complex128{}),
-			StringValue:     `"10 + 3i", "5 + 2i", "3 + 3i"`,
+			StringValue:     `"10+3i", "5+2i", "3+3i"`,
 			AssertFunc: func(i interface{}) {
 				expected := []complex128{10 + 3i, 5 + 2i, 3 + 3i}
 				actual := i.([]complex128)


### PR DESCRIPTION
Since go >= 1.15 has strconv.ParseComplex, let's delegate to that where
available.  strconv is also a bit stricter on the format of the complex
number string, so adjust tests to reflect that.  Since few (if any)
people are using this, it shouldn't matter much.