### PR TITLE
PFlag Float32 Handling

### DIFF
--- a/pflag/pflag.go
+++ b/pflag/pflag.go
@@ -263,7 +263,7 @@ func (s *Set) registerFlags(tmpl reflect.Value, ptyp reflect.Type) error {
 		case reflect.Float64:
 			f = s.Flags.Float64P(name, shorthand, fieldVal.Interface().(float64), help)
 		case reflect.Float32:
-			f = s.Flags.Float64P(name, shorthand, float64(fieldVal.Interface().(float32)), help)
+			f = s.Flags.Float32P(name, shorthand, fieldVal.Interface().(float32), help)
 		case reflect.Complex64:
 			f = fieldVal.Addr().Interface()
 			s.Flags.VarP(flaghelper.NewComplex64Var(fieldVal.Addr().Interface().(*complex64)), name, shorthand, help)

--- a/pflag/pflag_test.go
+++ b/pflag/pflag_test.go
@@ -101,6 +101,12 @@ func TestPFlags(t *testing.T) {
 			expected: &struct{ A int }{A: 42},
 		},
 		{
+			name:     "basic_float32_set",
+			tmpl:     &struct{ A float32 }{A: 4.5},
+			args:     []string{"--a=42.5"},
+			expected: &struct{ A float32 }{A: 42.5},
+		},
+		{
 			name:     "basic_string_defaulted",
 			tmpl:     &struct{ A string }{A: "foobar"},
 			args:     []string{},


### PR DESCRIPTION
Float32s were not handled correctly.  This partially fixes that, though
we will revisit the conversion logic later.