### PR TITLE
Fix slice-type-field handling for env source

### DIFF
--- a/tagformat/expand_tags.go
+++ b/tagformat/expand_tags.go
@@ -48,7 +48,13 @@ func (t *TagCopyingMangler) Mangle(sf reflect.StructField) ([]reflect.StructFiel
 // This just returns the first field, as Mangle only returns one field at a
 // time.
 func (t *TagCopyingMangler) Unmangle(sf reflect.StructField, vs []transform.FieldValueTuple) (reflect.Value, error) {
-	return vs[0].Value.Convert(sf.Type), nil
+	// we always return exactly one field in Mangle, so we can always
+	// return vs[0].Value (after a type conversion) without any issues
+	switch vs[0].Value.Kind() {
+	case reflect.Struct:
+		return vs[0].Value.Convert(sf.Type), nil
+	}
+	return vs[0].Value, nil
 }
 
 // ShouldRecurse is called after Mangle for each field so nested struct

--- a/tagformat/reformat_tags.go
+++ b/tagformat/reformat_tags.go
@@ -70,7 +70,10 @@ func (k *TagReformattingMangler) Mangle(sf reflect.StructField) ([]reflect.Struc
 func (k *TagReformattingMangler) Unmangle(sf reflect.StructField, vs []transform.FieldValueTuple) (reflect.Value, error) {
 	// we always return exactly one field in Mangle, so we can always
 	// return vs[0].Value (after a type conversion) without any issues
-	return vs[0].Value.Convert(sf.Type), nil
+	if vs[0].Value.Kind() == reflect.Struct {
+		return vs[0].Value.Convert(sf.Type), nil
+	}
+	return vs[0].Value, nil
 }
 
 // ShouldRecurse is called after Mangle for each field so nested struct

--- a/transform/transformer.go
+++ b/transform/transformer.go
@@ -268,14 +268,16 @@ FIELDITER:
 			if v.IsNil() {
 				// if it's nil, skip it, the unmangler isn't
 				// going to do anything useful on a nil-slice
+				// just make sure it has the right type.
+				mf[z].Value = reflect.Zero(fieldState.out[z].field.Type)
 				continue FIELDITER
 			}
-			mf[z].Value = reflect.MakeSlice(field.Field.Type, v.Len(), v.Cap())
+			mf[z].Value = reflect.MakeSlice(fieldState.out[z].field.Type, v.Len(), v.Cap())
 			fallthrough
 		case reflect.Array:
 			if fieldState.in.Type.Kind() == reflect.Array {
 				// we didn't fall-through
-				mf[z].Value = reflect.New(field.Field.Type).Elem()
+				mf[z].Value = reflect.New(fieldState.out[z].field.Type).Elem()
 			}
 			for l := 0; l < v.Len(); l++ {
 				av := v.Index(l)


### PR DESCRIPTION
Clean up type-handling when dealing with slices.

The struct-tag modifying manglers were playing a bit fast and loose with
their types. That was partially fixed in a previous change.

Actually set the correct types when slices are nil.