### PR TITLE
Watcher error reporting and dials callback manager

### DIFF
--- a/cb_mgr.go
+++ b/cb_mgr.go
@@ -1,0 +1,40 @@
+package dials
+
+import (
+	"context"
+	"fmt"
+)
+
+type callbackMgr struct {
+	p *Params
+
+	ch <-chan userCallbackEvent
+}
+
+type userCallbackEvent interface {
+	isUserCallbackEvent()
+}
+
+// watchErrorEvent sends the arguments to an OnWatchedError callback. The
+// fields here must stay in sync with the arguments to WatchedErrorHandler.
+type watchErrorEvent struct {
+	err                  error
+	oldConfig, newConfig interface{}
+}
+
+func (*watchErrorEvent) isUserCallbackEvent() {}
+
+var _ userCallbackEvent = (*watchErrorEvent)(nil)
+
+func (cbm *callbackMgr) runCBs(ctx context.Context) {
+	for ev := range cbm.ch {
+		switch e := ev.(type) {
+		case *watchErrorEvent:
+			if cbm.p.OnWatchedError != nil {
+				cbm.p.OnWatchedError(ctx, e.err, e.oldConfig, e.newConfig)
+			}
+		default:
+			panic(fmt.Errorf("unknown type %T for user callback event", ev))
+		}
+	}
+}

--- a/dials.go
+++ b/dials.go
@@ -11,9 +11,10 @@ import (
 )
 
 // WatchedErrorHandler is a callback that's called when something fails when
-// dials is operating in a watching mode.  Both oldConfig and NewConfig are
-// guaranteed to be populated with the same pointer-type that was passed to
-// `Config()`.
+// dials is operating in a watching mode.  If non-nil, both oldConfig and
+// newConfig are guaranteed to be populated with the same pointer-type that was
+// passed to `Config()`.
+// newConfig will be nil for errors that prevent stacking.
 type WatchedErrorHandler func(ctx context.Context, err error, oldConfig, newConfig interface{})
 
 // Params provides options for setting Dials's behavior in some cases.

--- a/dials.go
+++ b/dials.go
@@ -388,6 +388,13 @@ func (d *Dials) monitor(
 			switch v := watchTab.(type) {
 			case *valueUpdate:
 				d.updateSourceValue(ctx, t, sourceValues, v)
+			case *watchErrorReport:
+				d.submitCallback(ctx, &watchErrorEvent{
+					err: fmt.Errorf("error reported by source of type %T: %w",
+						v.source, v.err),
+					oldConfig: d.value.Load(),
+					newConfig: nil,
+				})
 			case *watcherDone:
 				if !d.markSourceDone(ctx, sourceValues, v) {
 					// if there are no watching sources, just exit.

--- a/dials.go
+++ b/dials.go
@@ -20,7 +20,7 @@ type WatchedErrorHandler func(ctx context.Context, err error, oldConfig, newConf
 type Params struct {
 	// OnWatchedError is called when either of several conditions are met:
 	//  - There is an error re-stacking the configuration
-	//  -
+	//  - One of the Sources implementing the Watcher interface reports an error
 	//  - a Verify() method fails after re-stacking when a new version is
 	//    provided by a watching source
 	OnWatchedError WatchedErrorHandler

--- a/dials.go
+++ b/dials.go
@@ -341,6 +341,8 @@ func (d *Dials) markSourceDone(
 	}
 
 	// check whether any sources have watching set to true
+	// (using a loop here because it's not worth maintaining an extra
+	// datastructure for an infrequent operation)
 	for _, sv := range sourceValues {
 		if sv.watching {
 			return true
@@ -355,6 +357,7 @@ func (d *Dials) monitor(
 	sourceValues []sourceValue,
 	watcherChan chan watchStatusUpdate,
 ) {
+	defer close(d.cbch)
 	for {
 		select {
 		case <-ctx.Done():

--- a/ez/ez.go
+++ b/ez/ez.go
@@ -160,12 +160,9 @@ func ConfigFileEnvFlag(ctx context.Context, cfg ConfigWithConfigPath, df Decoder
 	// Usually `dials.Config` is smart enough not to start a monitor when
 	// there are no `Watcher` implementations in the source-list, but the
 	// `Blank` source uses `Watcher` for its core functionality, so we need
-	// to cancel the context passed to `Config` to actually clean up
-	// resources.
+	// to shutdown the blank source to actually clean up resources.
 	if !option.watch {
-		configCtx, cancel := context.WithCancel(ctx)
-		defer cancel()
-		ctx = configCtx
+		defer blank.Done(ctx)
 	}
 	// OnWatchedError is never called from this goroutine, so it can be
 	// unbuffered without deadlocking.

--- a/sourcewrap/blank.go
+++ b/sourcewrap/blank.go
@@ -124,3 +124,23 @@ func (b *Blank) SetSource(ctx context.Context, s dials.Source) error {
 	}
 	return nil
 }
+
+// Done instructs Dials that this Blank source will never be used in a watching
+// mode ever again (allowing Dials to shutdown a goroutine once all other
+// sources implementing Watcher have called Done()).
+// This call is a nop if a source implementing the Watcher interface is present
+// within Blank. (Semantically, the WatchArgs are no longer the Blank's once a
+// Watcher-implementing Source is set)
+func (b *Blank) Done(ctx context.Context) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	switch b.inner.(type) {
+	case dials.Watcher:
+		return
+	default:
+	}
+	if b.wa == nil {
+		return
+	}
+	b.wa.Done(ctx)
+}


### PR DESCRIPTION
#### dials: add Done and ReportError methods to WatchArgs

This provides two capabilities:
 - When a watching source exits, or is unusable for some reason going
   forward, it can call `Done()`, thus letting the monitor() goroutine
   shutdown if all other sources are done. (independent of context
   cancelation)
 - When a source encounters an error that an application may be
   interested in, it can call WatchError to bubble it up.

#### dials: create a user callback execution goroutine/type (`callbackMgr`)

Running user callbacks is always a little dicey. They can block for
indefinite periods and gum of the functioning of an otherwise-functional
system.

Add a callbackMgr type with a runCBs method which will run in its own
goroutine and actually executes user callbacks.

The monitor closes the callback channel upon its exit, so we don't
need to worry about the callback channel hanging around indefinitely.

Let it finish handling any events before exiting. (it may pass a
canceled context to some callbacks, but there's nothing to do about
that)

#### file: hook up ReportError to WatchingSource

#### blank: expose Done()

Update the `ez` package