### PR TITLE
OnNewConfig callback

### DIFF
--- a/cb_mgr.go
+++ b/cb_mgr.go
@@ -15,6 +15,14 @@ type userCallbackEvent interface {
 	isUserCallbackEvent()
 }
 
+type newConfigEvent struct {
+	oldConfig, newConfig interface{}
+}
+
+func (*newConfigEvent) isUserCallbackEvent() {}
+
+var _ userCallbackEvent = (*newConfigEvent)(nil)
+
 // watchErrorEvent sends the arguments to an OnWatchedError callback. The
 // fields here must stay in sync with the arguments to WatchedErrorHandler.
 type watchErrorEvent struct {
@@ -32,6 +40,10 @@ func (cbm *callbackMgr) runCBs(ctx context.Context) {
 		case *watchErrorEvent:
 			if cbm.p.OnWatchedError != nil {
 				cbm.p.OnWatchedError(ctx, e.err, e.oldConfig, e.newConfig)
+			}
+		case *newConfigEvent:
+			if cbm.p.OnNewConfig != nil {
+				cbm.p.OnNewConfig(ctx, e.oldConfig, e.newConfig)
 			}
 		default:
 			panic(fmt.Errorf("unknown type %T for user callback event", ev))


### PR DESCRIPTION
Add a callback that's called just after installing a new configuration.

This eliminates the need for most use-cases to use an additional
goroutine to watch for config changes/updates.

The callback gets both the old and the new configs so clients can
differentially update other datastructures.

Since this new callback is executed by the callback manager goroutine,
and we try to keep callback execution serial, NewConfigHandler
implementations should be short to moderately long-running. (if they
take longer than the interval between updates to the config events
will back up)