### PR TITLE
actions: test with current go versions  (1.16 and 1.17)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,16 +7,16 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        goversion: [1.13, 1.14, 1.15]
+        goversion: [1.16, 1.17]
     steps:
       - name: Set up Go ${{matrix.goversion}} on ${{matrix.os}}
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: ${{matrix.goversion}}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: gofmt
         run: |

--- a/parse/complex.go
+++ b/parse/complex.go
@@ -1,3 +1,4 @@
+//go:build !go1.15
 // +build !go1.15
 
 package parse

--- a/parse/complex_go115.go
+++ b/parse/complex_go115.go
@@ -1,3 +1,4 @@
+//go:build go1.15
 // +build go1.15
 
 package parse

--- a/parse/complex_test.go
+++ b/parse/complex_test.go
@@ -1,3 +1,4 @@
+//go:build !go1.15
 // +build !go1.15
 
 package parse


### PR DESCRIPTION
Update the list of go versions with which we run tests.
Now 1.16 and 1.17.

Also update the setup-go and checkout helpers.

Note: we could add 1.18.0-beta1 to the list of versions, but that broke
on macos when I tested it. We can wait until 1.18 is actually released
to include 1.18.

Update the build tag constraints in the `complex` package to match `gofmt` output for more recent versions. (1.17+)