### PR TITLE
Go 1.18 generics/type-parameters

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,10 +7,10 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        goversion: [1.16, 1.17]
+        goversion: [1.18, '1.19.0-rc.1']
     steps:
       - name: Set up Go ${{matrix.goversion}} on ${{matrix.os}}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{matrix.goversion}}
         id: go

--- a/dials.go
+++ b/dials.go
@@ -59,11 +59,11 @@ type Params[T any] struct {
 // on Verify()) in VerifiedConfig for details)
 //
 // If complicated/blocking initialization/verification is necessary, one can either:
-//  - If not using any watching sources, do any verification with the returned
-//    config from Config.
-//  - If using at least one watching source, configure a goroutine to watch the
-//    channel returned by the `Dials.Events()` method that does its own
-//    installation after verifying the config.
+//   - If not using any watching sources, do any verification with the returned
+//     config from Config.
+//   - If using at least one watching source, configure a goroutine to watch the
+//     channel returned by the `Dials.Events()` method that does its own
+//     installation after verifying the config.
 //
 // More complicated verification/initialization should be done by
 // consuming from the channel returned by `Events()`.

--- a/dials.go
+++ b/dials.go
@@ -15,22 +15,22 @@ import (
 // newConfig are guaranteed to be populated with the same pointer-type that was
 // passed to `Config()`.
 // newConfig will be nil for errors that prevent stacking.
-type WatchedErrorHandler func(ctx context.Context, err error, oldConfig, newConfig interface{})
+type WatchedErrorHandler[T any] func(ctx context.Context, err error, oldConfig, newConfig *T)
 
 // NewConfigHandler is a callback that's called after a new config is installed.
 // Callbacks are run on a dedicated Goroutine, so one can do expensive/blocking
 // work in this callback, however, execution should not last longer than the
 // interval between new configs.
-type NewConfigHandler func(ctx context.Context, oldConfig, newConfig interface{})
+type NewConfigHandler[T any] func(ctx context.Context, oldConfig, newConfig *T)
 
 // Params provides options for setting Dials's behavior in some cases.
-type Params struct {
+type Params[T any] struct {
 	// OnWatchedError is called when either of several conditions are met:
 	//  - There is an error re-stacking the configuration
 	//  - One of the Sources implementing the Watcher interface reports an error
 	//  - a Verify() method fails after re-stacking when a new version is
 	//    provided by a watching source
-	OnWatchedError WatchedErrorHandler
+	OnWatchedError WatchedErrorHandler[T]
 
 	// SkipInitialVerification skips the initial call to `Verify()` on any
 	// configurations that implement the `VerifiedConfig` interface.
@@ -46,7 +46,7 @@ type Params struct {
 	// OnWatchedError callback, with callbacks being executed in-order.
 	// In the event that a call to OnNewConfig blocks too long, some calls
 	// may be dropped.
-	OnNewConfig NewConfigHandler
+	OnNewConfig NewConfigHandler[T]
 }
 
 // Config populates the passed in config struct by reading the values from the
@@ -67,7 +67,7 @@ type Params struct {
 //
 // More complicated verification/initialization should be done by
 // consuming from the channel returned by `Events()`.
-func (p Params) Config(ctx context.Context, t interface{}, sources ...Source) (*Dials, error) {
+func (p Params[T]) Config(ctx context.Context, t *T, sources ...Source) (*Dials[T], error) {
 
 	watcherChan := make(chan watchStatusUpdate)
 	computed := make([]sourceValue, len(sources))
@@ -113,9 +113,9 @@ func (p Params) Config(ctx context.Context, t interface{}, sources ...Source) (*
 		return nil, err
 	}
 
-	d := &Dials{
+	d := &Dials[T]{
 		value:       atomic.Value{},
-		updatesChan: make(chan interface{}, 1),
+		updatesChan: make(chan *T, 1),
 		params:      p,
 	}
 	d.value.Store(newValue)
@@ -123,7 +123,7 @@ func (p Params) Config(ctx context.Context, t interface{}, sources ...Source) (*
 	// Verify that the configuration is valid if a Verify() method is present.
 	if vf, ok := newValue.(VerifiedConfig); ok && !p.SkipInitialVerification {
 		if vfErr := vf.Verify(); vfErr != nil {
-			return nil, fmt.Errorf("Initial configuration verification failed: %w", vfErr)
+			return nil, fmt.Errorf("initial configuration verification failed: %w", vfErr)
 		}
 	}
 
@@ -134,12 +134,12 @@ func (p Params) Config(ctx context.Context, t interface{}, sources ...Source) (*
 		// the time.
 		cbch := make(chan userCallbackEvent, 64)
 		d.cbch = cbch
-		cbmgr := callbackMgr{
+		cbmgr := callbackMgr[T]{
 			p:  &p,
 			ch: cbch,
 		}
 		go cbmgr.runCBs(ctx)
-		go d.monitor(ctx, tVal.Interface(), computed, watcherChan)
+		go d.monitor(ctx, tVal.Interface().(*T), computed, watcherChan)
 	}
 	return d, nil
 }
@@ -150,8 +150,8 @@ func (p Params) Config(ctx context.Context, t interface{}, sources ...Source) (*
 // were set by previous sources
 // This top-level function is present for convenience and backwards
 // compatibility when there is no need to specify an error-handler.
-func Config(ctx context.Context, t interface{}, sources ...Source) (*Dials, error) {
-	return Params{}.Config(ctx, t, sources...)
+func Config[T any](ctx context.Context, t *T, sources ...Source) (*Dials[T], error) {
+	return Params[T]{}.Config(ctx, t, sources...)
 }
 
 // Source interface is implemented by each configuration source that is used to
@@ -277,49 +277,39 @@ type VerifiedConfig interface {
 }
 
 // Dials is the main access point for your configuration.
-type Dials struct {
+type Dials[T any] struct {
 	value       atomic.Value
-	updatesChan chan interface{}
-	params      Params
+	updatesChan chan *T
+	params      Params[T]
 	cbch        chan<- userCallbackEvent
-}
-
-// View returns the configuration struct populated.
-func (d *Dials) View() interface{} {
-	return d.value.Load()
 }
 
 // Events returns a channel that will get a message every time the configuration
 // is updated.
-func (d *Dials) Events() <-chan interface{} {
+func (d *Dials[T]) Events() <-chan *T {
 	return d.updatesChan
 }
 
 // Fill populates the passed struct with the current value of the configuration.
-// It will panic if the type of `blankConfig` does not match the type of the
-// configuration value passed to `Config` in the first place.
-func (d *Dials) Fill(blankConfig interface{}) {
-	bVal := reflect.ValueOf(blankConfig)
-	currentVal := reflect.ValueOf(d.value.Load())
+// It is a thin wrapper around assignment
+// deprecated: assign return value from View() instead
+func (d *Dials[T]) Fill(blankConfig *T) {
+	*blankConfig = *d.View()
+}
 
-	if bVal.Type() != currentVal.Type() {
-		panic(fmt.Sprintf(
-			"value to fill type (%s) does not match actual type (%s)",
-			bVal.Type(),
-			currentVal.Type(),
-		))
-	}
-
-	bVal.Elem().Set(currentVal.Elem())
+// View returns the configuration struct populated.
+func (d *Dials[T]) View() *T {
+	v, _ := d.value.Load().(*T)
+	return v
 }
 
 // returns the new value (if any)
-func (d *Dials) updateSourceValue(
+func (d *Dials[T]) updateSourceValue(
 	ctx context.Context,
-	t interface{},
+	t *T,
 	sourceValues []sourceValue,
 	watchTab *valueUpdate,
-) interface{} {
+) *T {
 	for i, sv := range sourceValues {
 		if watchTab.source == sv.source {
 			sourceValues[i].value = watchTab.value
@@ -328,8 +318,10 @@ func (d *Dials) updateSourceValue(
 	}
 	newInterface, stackErr := compose(t, sourceValues)
 	if stackErr != nil {
-		d.submitEvent(ctx, &watchErrorEvent{
-			err: stackErr, oldConfig: d.value.Load(), newConfig: newInterface,
+		oldVal, _ := d.value.Load().(*T)
+		newVal, _ := newInterface.(*T)
+		d.submitEvent(ctx, &watchErrorEvent[T]{
+			err: stackErr, oldConfig: oldVal, newConfig: newVal,
 		})
 		return nil
 	}
@@ -337,23 +329,29 @@ func (d *Dials) updateSourceValue(
 	// Verify that the configuration is valid if a Verify() method is present.
 	if vf, ok := newInterface.(VerifiedConfig); ok {
 		if vfErr := vf.Verify(); vfErr != nil {
-			d.submitEvent(ctx, &watchErrorEvent{
-				err: vfErr, oldConfig: d.value.Load(), newConfig: newInterface,
+			oldVal, _ := d.value.Load().(*T)
+
+			newVal := newInterface.(*T)
+
+			d.submitEvent(ctx, &watchErrorEvent[T]{
+				err: vfErr, oldConfig: oldVal, newConfig: newVal,
 			})
 			return nil
 		}
 	}
 
+	newVers := newInterface.(*T)
+
 	d.value.Store(newInterface)
 	select {
-	case d.updatesChan <- newInterface:
+	case d.updatesChan <- newVers:
 	default:
 	}
 
-	return newInterface
+	return newVers
 }
 
-func (d *Dials) markSourceDone(
+func (d *Dials[T]) markSourceDone(
 	ctx context.Context,
 	sourceValues []sourceValue,
 	watchTab *watcherDone,
@@ -377,7 +375,7 @@ func (d *Dials) markSourceDone(
 	return false
 }
 
-func (d *Dials) submitEvent(ctx context.Context, ev userCallbackEvent) {
+func (d *Dials[T]) submitEvent(ctx context.Context, ev userCallbackEvent) {
 	// don't panic
 	if d.cbch == nil {
 		return
@@ -390,9 +388,9 @@ func (d *Dials) submitEvent(ctx context.Context, ev userCallbackEvent) {
 	}
 }
 
-func (d *Dials) monitor(
+func (d *Dials[T]) monitor(
 	ctx context.Context,
-	t interface{},
+	t *T,
 	sourceValues []sourceValue,
 	watcherChan chan watchStatusUpdate,
 ) {
@@ -404,19 +402,19 @@ func (d *Dials) monitor(
 		case watchTab := <-watcherChan:
 			switch v := watchTab.(type) {
 			case *valueUpdate:
-				oldConfig := d.value.Load()
+				oldConfig, _ := d.value.Load().(*T)
 				newConfig := d.updateSourceValue(ctx, t, sourceValues, v)
 				if newConfig != nil {
-					d.submitEvent(ctx, &newConfigEvent{
+					d.submitEvent(ctx, &newConfigEvent[T]{
 						oldConfig: oldConfig,
 						newConfig: newConfig,
 					})
 				}
 			case *watchErrorReport:
-				d.submitEvent(ctx, &watchErrorEvent{
+				d.submitEvent(ctx, &watchErrorEvent[T]{
 					err: fmt.Errorf("error reported by source of type %T: %w",
 						v.source, v.err),
-					oldConfig: d.value.Load(),
+					oldConfig: d.View(),
 					newConfig: nil,
 				})
 			case *watcherDone:

--- a/ez/ez.go
+++ b/ez/ez.go
@@ -186,6 +186,7 @@ func fileSource(cfgPath string, decoder dials.Decoder, watch bool) (dials.Source
 //   - configuration file
 //   - environment variables
 //   - flags it registers with the standard library flags package
+//
 // The contents of cfg for the defaults
 // cfg.ConfigPath() is evaluated on the stacked config with the file-contents omitted (using a "blank" source)
 func ConfigFileEnvFlag[T any, TP ConfigWithConfigPath[T]](ctx context.Context, cfg TP, df DecoderFactory, options ...Option) (*dials.Dials[T], error) {

--- a/ez/ez_test.go
+++ b/ez/ez_test.go
@@ -56,7 +56,7 @@ func TestYAMLConfigEnvFlagWithValidConfig(t *testing.T) {
 			"Jack":  {},
 		},
 	}
-	populatedConf := view.View().(*config)
+	populatedConf := view.View()
 	assert.EqualValues(t, expectedConfig, *populatedConf)
 }
 
@@ -88,7 +88,7 @@ func TestYAMLConfigEnvFlagWithFileKeyNaming(t *testing.T) {
 			"Ringo":  "drums",
 		},
 	}
-	populatedConf := view.View().(*beatlesConfig)
+	populatedConf := view.View()
 	assert.EqualValues(t, expectedConfig, *populatedConf)
 }
 
@@ -150,7 +150,7 @@ func TestYAMLConfigEnvFlagWithValidatingConfigInitiallyValid(t *testing.T) {
 	defer os.Remove(path)
 
 	errCh := make(chan error)
-	errHandler := func(ctx context.Context, err error, oldConfig, newConfig interface{}) {
+	errHandler := func(ctx context.Context, err error, oldConfig, newConfig *validatingConfig) {
 		errCh <- err
 	}
 	c := &validatingConfig{Path: path}
@@ -164,7 +164,7 @@ func TestYAMLConfigEnvFlagWithValidatingConfigInitiallyValid(t *testing.T) {
 		Val2: "",
 		Set:  map[string]struct{}{},
 	}
-	populatedConf := view.View().(*validatingConfig)
+	populatedConf := view.View()
 	assert.EqualValues(t, expectedConfig, *populatedConf)
 
 	tmpPath2 := filepath.Join(tmpDir, "_tmp_fim1.yaml")
@@ -204,7 +204,7 @@ func TestJSONConfigEnvFlagWithNewConfigCallback(t *testing.T) {
 	require.NoError(t, ioutil.WriteFile(path, origJS, 0660))
 
 	newCfg := make(chan interface{}, 1)
-	newConfigCB := func(ctx context.Context, oldConfig, newConfig interface{}) {
+	newConfigCB := func(ctx context.Context, oldConfig, newConfig *validatingConfig) {
 		newCfg <- newConfig
 	}
 	c := &validatingConfig{Path: path}
@@ -218,7 +218,7 @@ func TestJSONConfigEnvFlagWithNewConfigCallback(t *testing.T) {
 		Val2: "",
 		Set:  map[string]struct{}{"foo": {}, "bar": {}, "baz": {}},
 	}
-	populatedConf := view.View().(*validatingConfig)
+	populatedConf := view.View()
 	assert.EqualValues(t, expectedConfig, *populatedConf)
 
 	select {
@@ -257,6 +257,6 @@ func TestJSONConfigEnvFlagWithNewConfigCallback(t *testing.T) {
 	assert.EqualValues(t, expectedFinalConfig, *finalCfg.(*validatingConfig))
 
 	finalViewEventCfg := <-view.Events()
-	assert.EqualValues(t, expectedFinalConfig, *finalViewEventCfg.(*validatingConfig))
-	assert.EqualValues(t, expectedFinalConfig, *view.View().(*validatingConfig))
+	assert.EqualValues(t, expectedFinalConfig, *finalViewEventCfg)
+	assert.EqualValues(t, expectedFinalConfig, *view.View())
 }

--- a/file/file.go
+++ b/file/file.go
@@ -247,17 +247,18 @@ func (ws *WatchingSource) Watch(
 
 // Kubernetes uses its AtomicWriter for updating configmaps, which has
 // a somewhat unique structure:
-//  It creates a timestamped tempdir named by
-//  `ioutil.TempDir(w.targetDir, time.Now().UTC().Format("..2006_01_02_15_04_05."))`
-//  which contains all the "projected" files, and a `..dir` symlink to that directory.
-//  It then creates symlinks from the user-visible location into the
-//  `..dir` directory, so it can populate a new timestamped dir and do
-//  an atomic rename (from `..data_tmp` to `..data`) of the symlink to
-//  make all contents of the configmap atomically updatable.
-//  The timestamped directory is then symlinked to `..data_tmp`, which
-//  is then atomically renamed over the `..data` directory.
-//  At this point, we don't care, but it then cleans up the old directory.
-//  doc for the k8s AtomicWriter: https://godoc.org/k8s.io/kubernetes/pkg/volume/util#AtomicWriter
+//
+//	It creates a timestamped tempdir named by
+//	`ioutil.TempDir(w.targetDir, time.Now().UTC().Format("..2006_01_02_15_04_05."))`
+//	which contains all the "projected" files, and a `..dir` symlink to that directory.
+//	It then creates symlinks from the user-visible location into the
+//	`..dir` directory, so it can populate a new timestamped dir and do
+//	an atomic rename (from `..data_tmp` to `..data`) of the symlink to
+//	make all contents of the configmap atomically updatable.
+//	The timestamped directory is then symlinked to `..data_tmp`, which
+//	is then atomically renamed over the `..data` directory.
+//	At this point, we don't care, but it then cleans up the old directory.
+//	doc for the k8s AtomicWriter: https://godoc.org/k8s.io/kubernetes/pkg/volume/util#AtomicWriter
 //
 // The upshot is that we need to watch the parent directory for
 // renames, (which may show up as create/delete pairs) that affect the

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -73,8 +73,7 @@ func TestWatchingFile(t *testing.T) {
 	d, err := dials.Config(ctx, myConfig, watchingFile)
 	assert.NoError(t, err)
 
-	c, ok := d.View().(*config)
-	assert.True(t, ok)
+	c := d.View()
 	assert.Equal(t, 42, c.SecretOfLife)
 	assert.Equal(t, 4, c.NumBeatles)
 
@@ -90,8 +89,7 @@ func TestWatchingFile(t *testing.T) {
 
 	wg.Wait()
 
-	c, ok = d.View().(*config)
-	assert.True(t, ok)
+	c = d.View()
 	assert.Equal(t, 47, c.SecretOfLife)
 	assert.Equal(t, 4, c.NumBeatles)
 }
@@ -133,8 +131,7 @@ func TestWatchingFileWithRelativePathAndChdir(t *testing.T) {
 	d, err := dials.Config(ctx, myConfig, watchingFile)
 	assert.NoError(t, err)
 
-	c, ok := d.View().(*config)
-	assert.True(t, ok)
+	c := d.View()
 	assert.Equal(t, 42, c.SecretOfLife)
 	assert.Equal(t, 4, c.NumBeatles)
 
@@ -154,8 +151,7 @@ func TestWatchingFileWithRelativePathAndChdir(t *testing.T) {
 
 	wg.Wait()
 
-	c, ok = d.View().(*config)
-	assert.True(t, ok)
+	c = d.View()
 	assert.Equal(t, 47, c.SecretOfLife)
 	assert.Equal(t, 4, c.NumBeatles)
 }
@@ -183,9 +179,7 @@ func TestWatchingFileWithRemove(t *testing.T) {
 	d, err := dials.Config(ctx, myConfig, watchingFile)
 	require.NoErrorf(t, err, "failed to construct watcher (on file %q)", firstConfig)
 
-	// let it panic (it's a test, and the panic trace will give us the data
-	// we want.
-	c := d.View().(*config)
+	c := d.View()
 	assert.Equal(t, 42, c.SecretOfLife)
 	assert.Equal(t, 4, c.NumBeatles)
 
@@ -210,7 +204,7 @@ func TestWatchingFileWithRemove(t *testing.T) {
 	cancel()
 
 	// should still be set to what it was before
-	c = d.View().(*config)
+	c = d.View()
 	assert.Equal(t, 42, c.SecretOfLife)
 	assert.Equal(t, 4, c.NumBeatles)
 }
@@ -239,8 +233,7 @@ func TestWatchingFileWithTrickle(t *testing.T) {
 	d, err := dials.Config(ctx, myConfig, watchingFile)
 	assert.NoError(t, err)
 
-	c, ok := d.View().(*config)
-	assert.True(t, ok)
+	c := d.View()
 	assert.Equal(t, 42, c.SecretOfLife)
 	assert.Equal(t, 4, c.NumBeatles)
 
@@ -287,8 +280,7 @@ func TestWatchingFileWithTrickle(t *testing.T) {
 	assert.EqualValues(t, atomic.LoadInt32(&counter), 1)
 
 	// should still be set to what it was before
-	c, ok = d.View().(*config)
-	assert.True(t, ok)
+	c = d.View()
 	assert.Equal(t, 11, c.SecretOfLife)
 	assert.Equal(t, 4, c.NumBeatles)
 }
@@ -339,8 +331,7 @@ func TestWatchingFileWithK8SEmulatedAtomicWriter(t *testing.T) {
 	d, err := dials.Config(ctx, myConfig, watchingFile)
 	assert.NoError(t, err)
 
-	c, ok := d.View().(*config)
-	assert.True(t, ok)
+	c := d.View()
 	assert.Equal(t, 42, c.SecretOfLife)
 	assert.Equal(t, 4, c.NumBeatles)
 
@@ -355,9 +346,8 @@ func TestWatchingFileWithK8SEmulatedAtomicWriter(t *testing.T) {
 			select {
 			case conf := <-d.Events():
 				atomic.AddInt32(&counter, 1)
-				c := conf.(*config)
-				assert.EqualValues(t, 4, c.NumBeatles)
-				assert.EqualValues(t, expectedSecret, c.SecretOfLife)
+				assert.EqualValues(t, 4, conf.NumBeatles)
+				assert.EqualValues(t, expectedSecret, conf.SecretOfLife)
 				expectedSecret++
 				received <- struct{}{}
 			case <-ctx.Done():
@@ -396,7 +386,7 @@ func TestWatchingFileWithK8SEmulatedAtomicWriter(t *testing.T) {
 	assert.EqualValues(t, atomic.LoadInt32(&counter), 13)
 
 	// let it panic if it isn't the &config type we expect
-	c = d.View().(*config)
+	c = d.View()
 	assert.Equal(t, 9+14, c.SecretOfLife)
 	assert.Equal(t, 4, c.NumBeatles)
 }

--- a/flag/flag.go
+++ b/flag/flag.go
@@ -122,7 +122,8 @@ func NewSetWithArgs(cfg *NameConfig, template interface{}, args []string) (*Set,
 // Must is a helper that wraps a call to a function returning (*Set, error)
 // and panics if the error is non-nil. It is intended for use in variable
 // initializations such as
-// 	var flagset = flag.Must(flag.NewCmdLineSet(flag.DefaultFlagNameConfig(), config))
+//
+//	var flagset = flag.Must(flag.NewCmdLineSet(flag.DefaultFlagNameConfig(), config))
 func Must(s *Set, err error) *Set {
 	if err != nil {
 		panic(fmt.Errorf("Error registering flags: %w", err))

--- a/go.mod
+++ b/go.mod
@@ -14,5 +14,5 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.0.0-20190312061237-fead79001313 // indirect
+	golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vimeo/dials
 
-go 1.13
+go 1.18
 
 require (
 	github.com/fatih/structtag v1.2.0
@@ -8,6 +8,11 @@ require (
 	github.com/pelletier/go-toml v1.6.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/sys v0.0.0-20190312061237-fead79001313 // indirect
 	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.0.0-20190312061237-fead79001313 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-golang.org/x/sys v0.0.0-20190312061237-fead79001313 h1:pczuHS43Cp2ktBEEmLwScxgjWsBSzdaQiKzUyf3DTTc=
-golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d h1:/m5NbqQelATgoSPVC2Z23sR4kVNokFwDDyWh/3rGY+I=
+golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/integrationtests/case_conversion_transformer_test.go
+++ b/integrationtests/case_conversion_transformer_test.go
@@ -73,8 +73,7 @@ func TestReformatDialsTags(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			c, ok := d.View().(*testConfig)
-			assert.True(t, ok)
+			c := d.View()
 			assert.Equal(t, "something", c.DatabaseName)
 			assert.Equal(t, "127.0.0.1", c.DatabaseAddress)
 			if !tc.ignoreIPv4 {
@@ -172,8 +171,7 @@ func TestReformatDialsTagsInNestedStruct(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			c, ok := d.View().(*testConfig)
-			assert.True(t, ok)
+			c := d.View()
 			assert.Equal(t, "something", c.DatabaseName)
 			assert.Equal(t, "test", c.DatabaseUser.Username)
 			assert.Equal(t, "password", c.DatabaseUser.Password)

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -30,8 +30,7 @@ func TestJSON(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	c, ok := d.View().(*testConfig)
-	assert.True(t, ok)
+	c := d.View()
 
 	assert.Equal(t, "something", c.Val1)
 	assert.Equal(t, 42, c.Val2)
@@ -66,8 +65,7 @@ func TestShallowlyNestedJSON(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	c, ok := d.View().(*testConfig)
-	assert.True(t, ok)
+	c := d.View()
 
 	assert.Equal(t, "something", c.DatabaseName)
 	assert.Equal(t, "test", c.DatabaseUser.Username)
@@ -110,8 +108,7 @@ func TestDeeplyNestedJSON(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	c, ok := d.View().(*testConfig)
-	assert.True(t, ok)
+	c := d.View()
 
 	assert.Equal(t, "something", c.DatabaseName)
 	assert.Equal(t, "test", c.DatabaseUser.Username)
@@ -160,8 +157,7 @@ func TestMoreDeeplyNestedJSON(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	c, ok := d.View().(*testConfig)
-	assert.True(t, ok)
+	c := d.View()
 
 	assert.Equal(t, "something", c.DatabaseName)
 	assert.Equal(t, "test", c.DatabaseUser.Username)

--- a/pflag/pflag.go
+++ b/pflag/pflag.go
@@ -112,7 +112,8 @@ func NewDefaultSetWithFlagSet(template interface{}, flagset *pflag.FlagSet) (*Se
 // Must is a helper that wraps a call to a function returning (*Set, error)
 // and panics if the error is non-nil. It is intended for use in variable
 // initializations such as
-// 	var flagset = pflag.Must(pflag.NewCmdLineSet(pflag.DefaultFlagNameConfig(), config))
+//
+//	var flagset = pflag.Must(pflag.NewCmdLineSet(pflag.DefaultFlagNameConfig(), config))
 func Must(s *Set, err error) *Set {
 	if err != nil {
 		panic(fmt.Errorf("Error registering flags: %w", err))

--- a/pflag/pflag_test.go
+++ b/pflag/pflag_test.go
@@ -45,10 +45,8 @@ func TestDirectBasicPFlag(t *testing.T) {
 	src.Flags.Usage()
 	t.Log(buf.String())
 
-	got, ok := d.View().(*Config)
-	if !ok {
-		t.Fatalf("want: *Config, got: %T", got)
-	}
+	got := d.View()
+
 	t.Logf("%+v", got)
 	if got.Hello != "foobar" {
 		t.Errorf("expected \"foobar\" for Hello, got %q", got.Hello)
@@ -80,218 +78,328 @@ func (u tu) UnmarshalText(data []byte) error {
 	return nil
 }
 
+func testWrapDials[T any](tmpl *T) func(ctx context.Context, src *Set) (any, error) {
+	return func(ctx context.Context, src *Set) (any, error) {
+		d, err := dials.Config(context.Background(), tmpl, src)
+		if d == nil {
+			return nil, err
+		}
+		return d.View(), err
+	}
+}
+
 func TestPFlags(t *testing.T) {
 	for _, itbl := range []struct {
-		name     string
-		tmpl     interface{}
+		name string
+		// returns the template and a callback for using the Set-typed source with dials
+		tmplCB   func() (any, func(ctx context.Context, src *Set) (any, error))
 		args     []string
-		expected interface{}
+		expected any
 		expErr   string
 	}{
 		{
-			name:     "basic_int_defaulted",
-			tmpl:     &struct{ A int }{A: 4},
+			name: "basic_int_defaulted",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A int }{A: 4}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{},
 			expected: &struct{ A int }{A: 4},
 		},
 		{
-			name:     "basic_int_set",
-			tmpl:     &struct{ A int }{A: 4},
+			name: "basic_int_set",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A int }{A: 4}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{"--a=42"},
 			expected: &struct{ A int }{A: 42},
 		},
 		{
-			name:     "basic_float32_set",
-			tmpl:     &struct{ A float32 }{A: 4.5},
+			name: "basic_float32_set",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A float32 }{A: 4.5}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{"--a=42.5"},
 			expected: &struct{ A float32 }{A: 42.5},
 		},
 		{
-			name:     "basic_string_defaulted",
-			tmpl:     &struct{ A string }{A: "foobar"},
+			name: "basic_string_defaulted",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A string }{A: "foobar"}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{},
 			expected: &struct{ A string }{A: "foobar"},
 		},
 		{
-			name:     "basic_string_set",
-			tmpl:     &struct{ A string }{A: "foobar"},
+			name: "basic_string_set",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A string }{A: "foobar"}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{"--a=bizzleboodle"},
 			expected: &struct{ A string }{A: "bizzleboodle"},
 		},
 		{
 			name: "shorthand_string_set",
-			tmpl: &struct {
-				A string `dialspflagshort:"b"`
-			}{A: "foobar"},
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct {
+					A string `dialspflagshort:"b"`
+				}{A: "foobar"}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{"-b=bizzleboodle"},
 			expected: &struct{ A string }{A: "bizzleboodle"},
 		},
 		{
-			name:     "basic_int16_default",
-			tmpl:     &struct{ A int16 }{A: 10},
+			name: "basic_int16_default",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A int16 }{A: 10}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{},
 			expected: &struct{ A int16 }{A: 10},
 		},
 		{
-			name:     "basic_int16_set_nooverflow",
-			tmpl:     &struct{ A int16 }{A: 10},
+			name: "basic_int16_set_nooverflow",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A int16 }{A: 10}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{"--a=128"},
 			expected: &struct{ A int16 }{A: 128},
 		},
 		{
-			name:     "basic_int16_set_overflow",
-			tmpl:     &struct{ A int16 }{A: 10},
+			name: "basic_int16_set_overflow",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A int16 }{A: 10}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{"--a=1000000"},
 			expected: nil,
 			expErr:   "failed to parse pflags: invalid argument \"1000000\" for \"--a\" flag: strconv.ParseInt: parsing \"1000000\": value out of range",
 		},
 		{
-			name:     "basic_int8_default",
-			tmpl:     &struct{ A int8 }{A: 10},
+			name: "basic_int8_default",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A int8 }{A: 10}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{},
 			expected: &struct{ A int8 }{A: 10},
 		},
 		{
-			name:     "basic_int8_set_nooverflow",
-			tmpl:     &struct{ A int8 }{A: 10},
+			name: "basic_int8_set_nooverflow",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A int8 }{A: 10}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{"--a=125"},
 			expected: &struct{ A int8 }{A: 125},
 		},
 		{
-			name:     "basic_int8_set_overflow",
-			tmpl:     &struct{ A int8 }{A: 10},
+			name: "basic_int8_set_overflow",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A int8 }{A: 10}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{"--a=1000000"},
 			expected: nil,
 			expErr:   "failed to parse pflags: invalid argument \"1000000\" for \"--a\" flag: strconv.ParseInt: parsing \"1000000\": value out of range",
 		},
 		{
-			name:     "map_string_string_set",
-			tmpl:     &struct{ A map[string]string }{A: map[string]string{"z": "i"}},
+			name: "map_string_string_set",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A map[string]string }{A: map[string]string{"z": "i"}}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{"--a=l:v"},
 			expected: &struct{ A map[string]string }{A: map[string]string{"l": "v"}},
 		},
 		{
-			name:     "map_string_string_default",
-			tmpl:     &struct{ A map[string]string }{A: map[string]string{"z": "i"}},
+			name: "map_string_string_default",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A map[string]string }{A: map[string]string{"z": "i"}}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{},
 			expected: &struct{ A map[string]string }{A: map[string]string{"z": "i"}},
 		},
 		{
-			name:     "map_string_string_slice_set",
-			tmpl:     &struct{ A map[string][]string }{A: map[string][]string{"z": {"i"}}},
+			name: "map_string_string_slice_set",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A map[string][]string }{A: map[string][]string{"z": {"i"}}}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{"--a=l:v,l:z"},
 			expected: &struct{ A map[string][]string }{A: map[string][]string{"l": {"v", "z"}}},
 		},
 		{
-			name:     "map_string_string_slice_default",
-			tmpl:     &struct{ A map[string][]string }{A: map[string][]string{"z": {"i"}}},
+			name: "map_string_string_slice_default",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A map[string][]string }{A: map[string][]string{"z": {"i"}}}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{},
 			expected: &struct{ A map[string][]string }{A: map[string][]string{"z": {"i"}}},
 		},
 		{
-			name:     "string_set_set",
-			tmpl:     &struct{ A map[string]struct{} }{A: map[string]struct{}{"i": {}}},
+			name: "string_set_set",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A map[string]struct{} }{A: map[string]struct{}{"i": {}}}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{"--a=v"},
 			expected: &struct{ A map[string]struct{} }{A: map[string]struct{}{"v": {}}},
 		},
 		{
-			name:     "string_set_default",
-			tmpl:     &struct{ A map[string]struct{} }{A: map[string]struct{}{"i": {}}},
+			name: "string_set_default",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A map[string]struct{} }{A: map[string]struct{}{"i": {}}}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{},
 			expected: &struct{ A map[string]struct{} }{A: map[string]struct{}{"i": {}}},
 		},
 		{
-			name:     "complex128_default",
-			tmpl:     &struct{ A complex128 }{A: 10 + 3i},
+			name: "complex128_default",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A complex128 }{A: 10 + 3i}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{},
 			expected: &struct{ A complex128 }{A: 10 + 3i},
 		},
 		{
-			name:     "complex128_set_nooverflow",
-			tmpl:     &struct{ A complex128 }{A: 10 + 3i},
+			name: "complex128_set_nooverflow",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A complex128 }{A: 10 + 3i}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{"--a=128+4i"},
 			expected: &struct{ A complex128 }{A: 128 + 4i},
 		},
 		{
-			name:     "complex64_default",
-			tmpl:     &struct{ A complex64 }{A: 10 + 3i},
+			name: "complex64_default",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A complex64 }{A: 10 + 3i}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{},
 			expected: &struct{ A complex64 }{A: 10 + 3i},
 		},
 		{
-			name:     "complex64_set_nooverflow",
-			tmpl:     &struct{ A complex64 }{A: 10 + 3i},
+			name: "complex64_set_nooverflow",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A complex64 }{A: 10 + 3i}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{"--a=128+4i"},
 			expected: &struct{ A complex64 }{A: 128 + 4i},
 		},
 		{
-			name:     "string_slice_set",
-			tmpl:     &struct{ A []string }{A: []string{"i"}},
+			name: "string_slice_set",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A []string }{A: []string{"i"}}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{"--a=v"},
 			expected: &struct{ A []string }{A: []string{"v"}},
 		},
 		{
-			name:     "string_slice_default",
-			tmpl:     &struct{ A []string }{A: []string{"i"}},
+			name: "string_slice_default",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A []string }{A: []string{"i"}}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{},
 			expected: &struct{ A []string }{A: []string{"i"}},
 		},
 		{
-			name:     "basic_duration_default",
-			tmpl:     &struct{ A time.Duration }{A: 10 * time.Nanosecond},
+			name: "basic_duration_default",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A time.Duration }{A: 10 * time.Nanosecond}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{},
 			expected: &struct{ A time.Duration }{A: 10 * time.Nanosecond},
 		},
 		{
-			name:     "basic_duration_set",
-			tmpl:     &struct{ A time.Duration }{A: 10 * time.Nanosecond},
+			name: "basic_duration_set",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A time.Duration }{A: 10 * time.Nanosecond}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{"--a=3ms"},
 			expected: &struct{ A time.Duration }{A: 3 * time.Millisecond},
 		},
 		{
 			// use time.Time for a of couple test-cases since it implements TextUnmarshaler
-			name:     "marshaler_time_set",
-			tmpl:     &struct{ A time.Time }{A: time.Time{}},
+			name: "marshaler_time_set",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A time.Time }{A: time.Time{}}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{"--a=2019-12-18T14:00:12Z"},
 			expected: &struct{ A time.Time }{A: time.Date(2019, time.December, 18, 14, 00, 12, 0, time.UTC)},
 		},
 		{
-			name:     "marshaler_time_default",
-			tmpl:     &struct{ A time.Time }{A: time.Time{}},
+			name: "marshaler_time_default",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ A time.Time }{A: time.Time{}}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{},
 			expected: &struct{ A time.Time }{A: time.Time{}},
 		},
 
 		{
-			name:     "hierarchical_int_defaulted",
-			tmpl:     &struct{ F struct{ A int } }{F: struct{ A int }{A: 4}},
+			name: "hierarchical_int_defaulted",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ F struct{ A int } }{F: struct{ A int }{A: 4}}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{},
 			expected: &struct{ F struct{ A int } }{F: struct{ A int }{A: 4}},
 		},
 		{
-			name:     "hierarchical_int_set",
-			tmpl:     &struct{ F struct{ A int } }{F: struct{ A int }{A: 4}},
+			name: "hierarchical_int_set",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ F struct{ A int } }{F: struct{ A int }{A: 4}}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{"--f-a=42"},
 			expected: &struct{ F struct{ A int } }{F: struct{ A int }{A: 42}},
 		},
 		{
-			name:     "hierarchical_ints_set",
-			tmpl:     &struct{ F struct{ A, B int } }{F: struct{ A, B int }{A: 4, B: 34}},
+			name: "hierarchical_ints_set",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ F struct{ A, B int } }{F: struct{ A, B int }{A: 4, B: 34}}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{"--f-a=42", "--f-b=4123"},
 			expected: &struct{ F struct{ A, B int } }{F: struct{ A, B int }{A: 42, B: 4123}},
 		},
 		{
-			name:     "hierarchical_ints_defaulted",
-			tmpl:     &struct{ F struct{ A, B int } }{F: struct{ A, B int }{A: 4, B: 34}},
+			name: "hierarchical_ints_defaulted",
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct{ F struct{ A, B int } }{F: struct{ A, B int }{A: 4, B: 34}}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:     []string{},
 			expected: &struct{ F struct{ A, B int } }{F: struct{ A, B int }{A: 4, B: 34}},
 		},
 		{
 			name: "hierarchical_ints_multi_struct_set",
-			tmpl: &struct {
-				F struct{ A, B int }
-				G struct{ A int }
-			}{F: struct{ A, B int }{A: 4, B: 34}, G: struct{ A int }{A: 5234}},
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct {
+					F struct{ A, B int }
+					G struct{ A int }
+				}{F: struct{ A, B int }{A: 4, B: 34}, G: struct{ A int }{A: 5234}}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args: []string{"--f-a=42", "--f-b=4123", "--g-a=5"},
 			expected: &struct {
 				F struct{ A, B int }
@@ -300,10 +408,13 @@ func TestPFlags(t *testing.T) {
 		},
 		{
 			name: "hierarchical_ints_multi_struct_partially_defaulted",
-			tmpl: &struct {
-				F struct{ A, B int }
-				G struct{ A int }
-			}{F: struct{ A, B int }{A: 4, B: 34}, G: struct{ A int }{A: 5234}},
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct {
+					F struct{ A, B int }
+					G struct{ A int }
+				}{F: struct{ A, B int }{A: 4, B: 34}, G: struct{ A int }{A: 5234}}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args: []string{"--f-a=42", "--g-a=5"},
 			expected: &struct {
 				F struct{ A, B int }
@@ -312,14 +423,17 @@ func TestPFlags(t *testing.T) {
 		},
 		{
 			name: "hierarchical_ints_multi_struct_with_hypen",
-			tmpl: &struct {
-				F struct{ A, B int }
-				G struct {
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct {
+					F struct{ A, B int }
+					G struct {
+						A int `dials:"-"`
+					}
+				}{F: struct{ A, B int }{A: 4, B: 34}, G: struct {
 					A int `dials:"-"`
-				}
-			}{F: struct{ A, B int }{A: 4, B: 34}, G: struct {
-				A int `dials:"-"`
-			}{A: 5234}},
+				}{A: 5234}}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args:   []string{"--f-a=42", "--g-a=5"},
 			expErr: "failed to parse pflags: unknown flag: --g-a",
 			expected: &struct {
@@ -329,23 +443,26 @@ func TestPFlags(t *testing.T) {
 		},
 		{
 			name: "hierarchical_ints_multi_struct_partially_defaulted _with_tags",
-			tmpl: &struct {
-				F struct {
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct {
+					F struct {
+						A int `dials:"NotA"`
+						B int
+					}
+					G struct {
+						A int `dialspflag:"NotB"`
+					}
+				}{F: struct {
 					A int `dials:"NotA"`
 					B int
-				}
-				G struct {
-					A int `dialspflag:"NotB"`
-				}
-			}{F: struct {
-				A int `dials:"NotA"`
-				B int
-			}{
-				A: 4, B: 34,
+				}{
+					A: 4, B: 34,
+				},
+					G: struct {
+						A int `dialspflag:"NotB"`
+					}{A: 5234}}
+				return &cfg, testWrapDials(&cfg)
 			},
-				G: struct {
-					A int `dialspflag:"NotB"`
-				}{A: 5234}},
 			args: []string{"--f-NotA=42", "--NotB=76"},
 			expected: &struct {
 				F struct{ A, B int }
@@ -353,11 +470,14 @@ func TestPFlags(t *testing.T) {
 			}{F: struct{ A, B int }{A: 42, B: 34}, G: struct{ A int }{A: 76}},
 		}, {
 			name: "non_pointer_text_unmarshal_implementation",
-			tmpl: &struct {
-				T tu
-			}{T: tu{
-				Text: "Hello",
-			}},
+			tmplCB: func() (any, func(ctx context.Context, src *Set) (any, error)) {
+				cfg := struct {
+					T tu
+				}{T: tu{
+					Text: "Hello",
+				}}
+				return &cfg, testWrapDials(&cfg)
+			},
 			args: []string{"--t=foobar"},
 			expected: &struct {
 				T tu
@@ -377,16 +497,17 @@ func TestPFlags(t *testing.T) {
 				FieldNameEncodeCasing: caseconversion.EncodeUpperSnakeCase,
 				TagEncodeCasing:       caseconversion.EncodeKebabCase,
 			}
-			s, setupErr := NewSetWithArgs(nameConfig, tbl.tmpl, tbl.args)
+			tmpl, run := tbl.tmplCB()
+			s, setupErr := NewSetWithArgs(nameConfig, tmpl, tbl.args)
 			require.NoError(t, setupErr, "failed to setup Set")
 
-			d, cfgErr := dials.Config(ctx, tbl.tmpl, s)
+			c, cfgErr := run(ctx, s)
 			if tbl.expErr != "" {
 				require.EqualError(t, cfgErr, tbl.expErr)
 				return
 			}
 			require.NoError(t, cfgErr, "failed to stack/Value()")
-			assert.EqualValues(t, tbl.expected, d.View())
+			assert.EqualValues(t, tbl.expected, c)
 		})
 	}
 }
@@ -407,10 +528,7 @@ func TestMust(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, ok := d.View().(*Config)
-	if !ok {
-		t.Fatalf("want: *Config, got: %T", got)
-	}
+	got := d.View()
 
 	if got.Hello != "foobar" {
 		t.Errorf("expected \"foobar\" for Hello, got %q", got.Hello)

--- a/sourcewrap/blank_test.go
+++ b/sourcewrap/blank_test.go
@@ -97,7 +97,7 @@ func TestBlankSource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to construct View: %s", err)
 	}
-	initConf := d.View().(*basicConf)
+	initConf := d.View()
 	if *initConf != c {
 		t.Errorf("unexpected initial config: got %+v; expected %+v", *initConf, c)
 	}
@@ -110,8 +110,7 @@ func TestBlankSource(t *testing.T) {
 	}
 
 	// Await the new value, since it's sent asynchronously
-	newConfIface := <-d.Events()
-	newConf := newConfIface.(*basicConf)
+	newConf := <-d.Events()
 	if *newConf != c {
 		t.Errorf("unexpected new config: got %+v; expected %+v", *newConf, c)
 	}
@@ -139,7 +138,7 @@ func TestBlankSourceError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to construct View: %s", err)
 	}
-	initConf := d.View().(*basicConf)
+	initConf := d.View()
 	if *initConf != c {
 		t.Errorf("unexpected initial config: got %+v; expected %+v", *initConf, c)
 	}
@@ -188,7 +187,7 @@ func TestBlankSourceWatcher(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to construct View: %s", err)
 	}
-	initConf := d.View().(*basicConf)
+	initConf := d.View()
 	if *initConf != c {
 		t.Errorf("unexpected initial config: got %+v; expected %+v", *initConf, c)
 	}
@@ -202,8 +201,7 @@ func TestBlankSourceWatcher(t *testing.T) {
 
 	{
 		// Await the new value, since it's sent asynchronously
-		newConfIface := <-d.Events()
-		newConf := newConfIface.(*basicConf)
+		newConf := <-d.Events()
 		if *newConf != c {
 			t.Errorf("unexpected new config: got %+v; expected %+v", *newConf, c)
 		}
@@ -216,8 +214,7 @@ func TestBlankSourceWatcher(t *testing.T) {
 	triv.poke(ctx)
 	{
 		// Await the new value, since it's sent asynchronously
-		newConfIface := <-d.Events()
-		newConf := newConfIface.(*basicConf)
+		newConf := <-d.Events()
 		if *newConf != c {
 			t.Errorf("unexpected new config: got %+v; expected %+v", *newConf, c)
 		}
@@ -249,7 +246,7 @@ func TestBlankSourceErrorWatcher(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to construct View: %s", err)
 	}
-	initConf := d.View().(*basicConf)
+	initConf := d.View()
 	if *initConf != c {
 		t.Errorf("unexpected initial config: got %+v; expected %+v", *initConf, c)
 	}
@@ -268,8 +265,7 @@ func TestBlankSourceErrorWatcher(t *testing.T) {
 
 	{
 		// Await the new value, since it's sent asynchronously
-		newConfIface := <-d.Events()
-		newConf := newConfIface.(*basicConf)
+		newConf := <-d.Events()
 		if *newConf != c {
 			t.Errorf("unexpected new config: got %+v; expected %+v", *newConf, c)
 		}

--- a/sourcewrap/transforming_source_test.go
+++ b/sourcewrap/transforming_source_test.go
@@ -56,7 +56,7 @@ func TestTransformingDecoder(t *testing.T) {
 	d, err := dials.Config(ctx, &c, &ss)
 	require.NoError(t, err)
 
-	theConf := d.View().(*conf)
+	theConf := d.View()
 	assert.Len(t, theConf.Set, 3)
 	assert.Contains(t, theConf.Set, "a")
 	assert.Contains(t, theConf.Set, "b")

--- a/toml/toml_test.go
+++ b/toml/toml_test.go
@@ -30,8 +30,7 @@ func TestDecoder(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	c, ok := d.View().(*testConfig)
-	require.True(t, ok)
+	c := d.View()
 
 	assert.Equal(t, "something", c.Val1)
 	assert.Equal(t, 42, c.Val2)
@@ -63,8 +62,7 @@ func TestShallowlyNestedTOML(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	c, ok := d.View().(*testConfig)
-	assert.True(t, ok)
+	c := d.View()
 
 	assert.Equal(t, "something", c.DatabaseName)
 	assert.Equal(t, "test", c.DatabaseUser.Username)
@@ -102,8 +100,7 @@ func TestDeeplyNestedTOML(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	c, ok := d.View().(*testConfig)
-	assert.True(t, ok)
+	c := d.View()
 
 	assert.Equal(t, "something", c.DatabaseName)
 	assert.Equal(t, "test", c.DatabaseUser.Username)
@@ -144,8 +141,7 @@ func TestMoreDeeplyNestedTOML(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	c, ok := d.View().(*testConfig)
-	assert.True(t, ok)
+	c := d.View()
 
 	assert.Equal(t, "something", c.DatabaseName)
 	assert.Equal(t, "test", c.DatabaseUser.Username)

--- a/yaml/yaml_test.go
+++ b/yaml/yaml_test.go
@@ -31,8 +31,7 @@ func TestYAML(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	c, ok := d.View().(*testConfig)
-	require.True(t, ok)
+	c := d.View()
 
 	assert.Equal(t, "something", c.Val1)
 	assert.Equal(t, 42, c.Val2)
@@ -77,8 +76,7 @@ func TestShallowlyNestedYAML(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	c, ok := d.View().(*testConfig)
-	assert.True(t, ok)
+	c := d.View()
 
 	assert.Equal(t, "something", c.DatabaseName)
 	assert.Equal(t, "test", c.DatabaseUser.Username)
@@ -129,8 +127,7 @@ func TestMoreDeeplyNestedYAML(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	c, ok := d.View().(*testConfig)
-	assert.True(t, ok)
+	c := d.View()
 
 	assert.Equal(t, "something", c.DatabaseName)
 	assert.Equal(t, "test", c.DatabaseUser.Username)


### PR DESCRIPTION
Clean up the top-level interface a bit by using go 1.18 generics. This
adds a bunch of type-safety, and eliminates a few pitfalls.

I'm leaving Fill() and Events() for now, but I'll remove them in a later
change. (I didn't want to update all the tests yet.)


Update tests to remove type-asserts and convert some template-values (of type `interface{}`/`any`) to use callbacks so the config-type is statically available at compile-time when `dials.Config` or `(dials.Param).Config()` is called.

### ez
Two parts:
 - easy: add type-parameters to the top-level functions so we get the
   right types passed down to dials.Config and friends.
 - annoying: Unfortunately, for go 1.18, type-inference on
   generic-parameters doesn't look at return values and where they're
   assigned, so if we use the simple, straightforward and safe
   implementation adding type-params to `Option`, we force callers to
   always specify type-params.

For now, address the Options situation by having two interfaces and
generating a runtime panic if a caller passes the wrong type for the
callback. (We'll need a better solution, but this is fairly reasonable
for the moment)

### Github Actions
Run with go 1.18 and go 1.19RC1

Reformat the repo with the go 1.19RC1 `gofmt` to pick up the new comment handling changes.