### PR TITLE
dials: add ViewVersion to eliminate races in callback registration.

### DIFF
--- a/dials_118.go
+++ b/dials_118.go
@@ -16,6 +16,16 @@ type Dials[T any] struct {
 
 // View returns the configuration struct populated.
 func (d *Dials[T]) View() *T {
-	v, _ := d.value.Load().(*T)
-	return v
+	v, _ := d.value.Load().(*versionedConfig[T])
+	// v cannot be nil because we initialize this value immediately after
+	// creating the the Dials object
+	return v.cfg
+}
+
+// View returns the configuration struct populated, and an opaque token.
+func (d *Dials[T]) ViewVersion() (*T, CfgSerial[T]) {
+	v, _ := d.value.Load().(*versionedConfig[T])
+	// v cannot be nil because we initialize this value immediately after
+	// creating the the Dials object
+	return v.cfg, CfgSerial[T]{s: v.serial, cfg: v.cfg}
 }

--- a/dials_119.go
+++ b/dials_119.go
@@ -8,7 +8,7 @@ import (
 
 // Dials is the main access point for your configuration.
 type Dials[T any] struct {
-	value       atomic.Pointer[T]
+	value       atomic.Pointer[versionedConfig[T]]
 	updatesChan chan *T
 	params      Params[T]
 	cbch        chan<- userCallbackEvent
@@ -16,5 +16,17 @@ type Dials[T any] struct {
 
 // View returns the configuration struct populated.
 func (d *Dials[T]) View() *T {
-	return d.value.Load()
+	versioned := d.value.Load()
+	// v cannot be nil because we initialize this value immediately after
+	// creating the the Dials object
+	return versioned.cfg
+}
+
+// View returns the configuration struct populated, and an opaque token.
+func (d *Dials[T]) ViewVersion() (*T, CfgSerial[T]) {
+	versioned := d.value.Load()
+	// v cannot be nil because we initialize this value immediately after
+	// creating the the Dials object
+	return versioned.cfg, CfgSerial[T]{s: versioned.serial, cfg: versioned.cfg}
+
 }


### PR DESCRIPTION
The next change will introduce a way to register (and unregister)
callbacks at runtime, with active watchers. To decided whether or not to
immediately call the callback with the current config version. In
particular, it's likely that the caller used a specific version for
setting up the structs/objects that will be manipulated by the callback.
That config-version is the relevant version.

The new CfgSerial type includes a backpointer to the version it refers
to so if the new-config callback needs to deliver a new configuration,
because the "current" version may be later. This way we don't need to
hold onto all versions we've ever seen in order to deliver a catch-up
new-config callback.