### PR TITLE
dials: runtime callback (un)registration

### DIFF
--- a/cb_mgr.go
+++ b/cb_mgr.go
@@ -17,6 +17,7 @@ type userCallbackEvent interface {
 
 type newConfigEvent[T any] struct {
 	oldConfig, newConfig *T
+	serial               uint64
 }
 
 func (*newConfigEvent[T]) isUserCallbackEvent() {}
@@ -34,7 +35,37 @@ func (*watchErrorEvent[T]) isUserCallbackEvent() {}
 
 var _ userCallbackEvent = (*watchErrorEvent[struct{}])(nil)
 
+type userCallbackHandle[T any] struct {
+	cb        NewConfigHandler[T]
+	minSerial uint64
+}
+
+type userCallbackRegistration[T any] struct {
+	handle *userCallbackHandle[T]
+	serial *CfgSerial[T]
+}
+
+func (*userCallbackRegistration[T]) isUserCallbackEvent() {}
+
+var _ userCallbackEvent = (*userCallbackRegistration[struct{}])(nil)
+
+type userCallbackUnregister[T any] struct {
+	// handle describes the relevant callback, and is the key in the newCfgCBs set tracked by
+	// runCBs.
+	handle *userCallbackHandle[T]
+	// done is closed by runCBs immediately after it's removed the handle from its set of user
+	// callbacks to run.
+	done chan<- struct{}
+}
+
+func (*userCallbackUnregister[T]) isUserCallbackEvent() {}
+
+var _ userCallbackEvent = (*userCallbackUnregister[struct{}])(nil)
+
 func (cbm *callbackMgr[T]) runCBs(ctx context.Context) {
+	newCfgCBs := make(map[*userCallbackHandle[T]]struct{}, 0)
+	lastSerial := uint64(0)
+	lastVersion := (*T)(nil)
 	for ev := range cbm.ch {
 		switch e := ev.(type) {
 		case *watchErrorEvent[T]:
@@ -42,9 +73,30 @@ func (cbm *callbackMgr[T]) runCBs(ctx context.Context) {
 				cbm.p.OnWatchedError(ctx, e.err, e.oldConfig, e.newConfig)
 			}
 		case *newConfigEvent[T]:
+			lastSerial = e.serial
+			lastVersion = e.newConfig
 			if cbm.p.OnNewConfig != nil {
 				cbm.p.OnNewConfig(ctx, e.oldConfig, e.newConfig)
 			}
+			for cbh := range newCfgCBs {
+				if cbh.minSerial >= e.serial {
+					// Skip the callback if it was registered with a serial for
+					// a version that we haven't caught up to yet.
+					continue
+				}
+				cbh.cb(ctx, e.oldConfig, e.newConfig)
+			}
+		case *userCallbackRegistration[T]:
+			// Serial values are assigned sequentially, so make sure we don't deliver an
+			// older config if we've fallen behind.
+			if e.serial.cfg != nil && e.serial.s < lastSerial {
+				e.handle.cb(ctx, e.serial.cfg, lastVersion)
+			}
+			// add this callback to the set of callbacks
+			newCfgCBs[e.handle] = struct{}{}
+		case *userCallbackUnregister[T]:
+			delete(newCfgCBs, e.handle)
+			close(e.done)
 		default:
 			panic(fmt.Errorf("unknown type %T for user callback event", ev))
 		}

--- a/dials_test.go
+++ b/dials_test.go
@@ -3,8 +3,12 @@ package dials
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"runtime"
+	"strconv"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -432,7 +436,7 @@ func TestWatcherWithDoneAndErrorCallback(t *testing.T) {
 	}
 }
 
-func TestConfigWithNewConfigCallback(t *testing.T) {
+func TestConfigWithNewConfigCallbacks(t *testing.T) {
 	t.Parallel()
 	type testConfig struct {
 		Foo string
@@ -476,9 +480,40 @@ func TestConfigWithNewConfigCallback(t *testing.T) {
 	// overwrite our original "base" to verify deep-copying is doing its job.
 	d.Fill(&base)
 	assert.Equal(t, "foozle", base.Foo)
+	_, initSerial := d.ViewVersion()
+
+	// no catch-up for either of these. We've registered the config with
+	// the only version of the config that's ever existed (for this dials object).
+	// we'll unregister it immediately.
+	assert.True(t, d.RegisterCallback(ctx, initSerial, func(ctx context.Context, oldConf, newConf *testConfig) {
+		t.Error("unexpected call of config with current version")
+	})(ctx), "unregister failed")
+	// similar, but using a zero-value for the serial (again, unregister immediately
+	assert.True(t, d.RegisterCallback(ctx, CfgSerial[testConfig]{}, func(ctx context.Context, oldConf, newConf *testConfig) {
+		t.Error("unexpected call of config with zero-valued serial")
+	})(ctx), "unregister failed")
+
+	// We'll be setting this value on the next config (just a bit below).
+	fimStr := "fim"
+
+	// we'll register 30 callbacks, and then unregister them after the next event
+	cbcalls := uint32(0)
+	unregCBs := make([]UnregisterCBFunc, 30)
+	for z := range unregCBs {
+		idx := z
+		CBcallCount := 0
+		cb := func(ctx context.Context, oldConf, newConf *testConfig) {
+			atomic.AddUint32(&cbcalls, 1)
+			assert.Equalf(t, newConf.Foo, fimStr, "cb %d", idx)
+			CBcallCount++
+			if CBcallCount > 1 {
+				t.Errorf("callback %d called too many times: %d", idx, CBcallCount)
+			}
+		}
+		unregCBs[z] = d.RegisterCallback(ctx, initSerial, cb)
+	}
 
 	// Push a new value, that should overlay on top of the base
-	fimStr := "fim"
 	fimConfig := ptrifiedConfig{
 		Foo: &fimStr,
 	}
@@ -489,6 +524,15 @@ func TestConfigWithNewConfigCallback(t *testing.T) {
 	assert.Equal(t, "foozle", oc.Foo)
 	assert.Equal(t, "fim", d.View().Foo)
 
+	// unregister all the callbacks we registered above.
+	for _, unregCB := range unregCBs {
+		assert.True(t, unregCB(ctx))
+	}
+
+	// we're now certain that all our callbacks have been called and
+	// unregistered. Check the value of cbcalls.
+	assert.Equal(t, uint32(len(unregCBs)), atomic.LoadUint32(&cbcalls))
+
 	// push another empty config
 	w.send(ctx, reflect.ValueOf(emptyConf))
 	finalConf := <-newConf
@@ -496,4 +540,208 @@ func TestConfigWithNewConfigCallback(t *testing.T) {
 	ocFinal := <-oldConf
 	assert.Equal(t, "fim", ocFinal.Foo)
 	assert.Equal(t, "foo", d.View().Foo)
+}
+
+func TestConfigWithNewConfigCallbacksSaturate(t *testing.T) {
+	t.Parallel()
+	type testConfig struct {
+		Foo string
+		Gen uint64
+	}
+
+	type ptrifiedConfig struct {
+		Foo *string
+		Gen *uint64
+	}
+
+	base := testConfig{
+		Foo: "foo",
+		Gen: 0,
+	}
+	emptyConf := ptrifiedConfig{
+		Foo: nil,
+		Gen: nil,
+	}
+	uint64Ptr := func(z uint64) *uint64 {
+		return &z
+	}
+	// Push a new value, that should overlay on top of the base
+	foozleStr := "foozle"
+	foozleConfig := ptrifiedConfig{
+		Foo: &foozleStr,
+		Gen: uint64Ptr(0),
+	}
+
+	// setup a cancelable context so the monitor goroutine gets shutdown.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// give oldConf a large capacity (we don't want to block on both)
+	oldConf := make(chan *testConfig, 128)
+	// we'll use this to block up the callback goroutine
+	newConf := make(chan *testConfig)
+	w := fakeWatchingSource{fakeSource: fakeSource{outVal: foozleConfig}}
+	p := Params[testConfig]{
+		OnWatchedError:          nil,
+		SkipInitialVerification: false,
+		OnNewConfig: func(ctx context.Context, oldConfig, newConfig *testConfig) {
+			oldConf <- oldConfig
+			newConf <- newConfig
+		},
+	}
+	d, err := p.Config(ctx, &base, &fakeSource{outVal: emptyConf}, &w)
+	require.NoError(t, err)
+
+	// pull in the existing value and verify that it works as intended.
+	// overwrite our original "base" to verify deep-copying is doing its job.
+	d.Fill(&base)
+	assert.Equal(t, "foozle", base.Foo)
+	_, initSerial := d.ViewVersion()
+
+	// we don't actually want to fill up the event channel, but give enough configs
+	cfgCnt := cap(d.cbch) - 20
+
+	// we'll register 30 callbacks, and then unregister them after the next event
+	cbcalls := uint32(0)
+	unregCBs := make([]UnregisterCBFunc, 30)
+	for z := range unregCBs {
+		idx := z
+		CBcallCount := 0
+		cb := func(ctx context.Context, oldConf, newConf *testConfig) {
+			atomic.AddUint32(&cbcalls, 1)
+			expFooVal := "fizzle" + strconv.Itoa(CBcallCount)
+			if CBcallCount == cfgCnt {
+				expFooVal = "fim"
+			}
+			assert.Equalf(t, newConf.Foo, expFooVal, "cb %d", idx)
+			CBcallCount++
+			if CBcallCount > cfgCnt+1 {
+				t.Errorf("callback %d called too many times: %d", idx, CBcallCount)
+			}
+		}
+		unregCBs[z] = d.RegisterCallback(ctx, initSerial, cb)
+	}
+
+	// Before we send new events, make sure that everything's caught up
+	// (the unregister call waits until its message is processed)
+	assert.True(t, d.RegisterCallback(ctx, CfgSerial[testConfig]{}, func(ctx context.Context, oldConf, newConf *testConfig) {
+		t.Error("unexpected call of config with zero-valued serial")
+	})(ctx), "unregister failed")
+
+	for z := 0; z < cfgCnt; z++ {
+		expFooVal := "fizzle" + strconv.Itoa(z)
+		fimConfig := ptrifiedConfig{
+			Foo: &expFooVal,
+			Gen: uint64Ptr(uint64(z) + 1),
+		}
+		w.send(ctx, reflect.ValueOf(fimConfig))
+	}
+	// We now have a channel full of deferred callbacks, which will get
+	// delivered (since we filled up the channel).
+	fullVers, fullSerial := d.ViewVersion()
+	if !strings.HasPrefix(fullVers.Foo, "fizzle") {
+		t.Errorf("unexpected fullVers.Foo prefix: %s", fullVers.Foo)
+	}
+	if fullVers.Gen > uint64(cfgCnt) {
+		t.Errorf("Gen value too large: %d", fullVers.Gen)
+	}
+
+	regUnregDone := make(chan struct{})
+
+	// this will block until we've cleared out the newConf values.
+	go func() {
+		assert.True(t, d.RegisterCallback(ctx, fullSerial, func(ctx context.Context, oldConf, newConf *testConfig) {
+			// we have a race in registration, skip anything with a
+			// generation between the one on fullVers and the last
+			// enqueued value so far
+			if newConf.Gen > fullVers.Gen && newConf.Gen <= uint64(cfgCnt) {
+				return
+			}
+			t.Errorf("unexpected call of config with later version (got Gen: %d)", newConf.Gen)
+		})(ctx), "unregister failed")
+		close(regUnregDone)
+	}()
+
+	for z := 0; z < cfgCnt; z++ {
+		c := <-newConf
+		expFooVal := "fizzle" + strconv.Itoa(int(c.Gen-1))
+		assert.Equal(t, expFooVal, c.Foo)
+		<-oldConf
+	}
+	// now, our unregister should have completed
+	<-regUnregDone
+
+	// We'll be setting this value on the next config (just a bit below).
+	fimStr := "fim"
+	// Push a new value, that should overlay on top of the base
+	fimConfig := ptrifiedConfig{
+		Foo: &fimStr,
+		Gen: uint64Ptr(uint64(cfgCnt) + 2),
+	}
+	w.send(ctx, reflect.ValueOf(fimConfig))
+	c := <-newConf
+	assert.Equal(t, "fim", c.Foo)
+	assert.Equal(t, uint64(cfgCnt)+2, c.Gen)
+	oc := <-oldConf
+	assert.Equal(t, "fizzle43", oc.Foo)
+	assert.Equal(t, uint64(cfgCnt), oc.Gen)
+	assert.Equal(t, "fim", d.View().Foo)
+
+	// unregister all the callbacks we registered above.
+	for _, unregCB := range unregCBs {
+		assert.True(t, unregCB(ctx))
+	}
+
+	// we're now certain that all our callbacks have been called and
+	// unregistered. Check the value of cbcalls.
+	assert.Equal(t, uint32(len(unregCBs)*(cfgCnt+1)), atomic.LoadUint32(&cbcalls))
+
+	// push another empty config
+	w.send(ctx, reflect.ValueOf(emptyConf))
+	finalConf := <-newConf
+	assert.Equal(t, "foo", finalConf.Foo)
+	ocFinal := <-oldConf
+	assert.Equal(t, "fim", ocFinal.Foo)
+	assert.Equal(t, "foo", d.View().Foo)
+}
+
+func ExampleDials_RegisterCallback() {
+	// setup a cancelable context so the monitor goroutine gets shutdown.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	type testConfig struct {
+		Foo string
+	}
+
+	type ptrifiedConfig struct {
+		Foo *string
+	}
+
+	base := testConfig{
+		Foo: "foo",
+	}
+	// Push a new value, that should overlay on top of the base
+	foozleStr := "foozle"
+	foozleConfig := ptrifiedConfig{
+		Foo: &foozleStr,
+	}
+
+	w := fakeWatchingSource{fakeSource: fakeSource{outVal: foozleConfig}}
+	d, dialsErr := Config(ctx, &base, &w)
+	if dialsErr != nil {
+		panic("unexpected error: " + dialsErr.Error())
+	}
+
+	cfg, serialToken := d.ViewVersion()
+	fmt.Printf("Foo: %s\n", cfg.Foo)
+
+	unregCB := d.RegisterCallback(ctx, serialToken, func(ctx context.Context, oldCfg, newCfg *testConfig) {
+		panic("not getting called this time")
+	})
+
+	unregCB(ctx)
+
+	// Output:
+	// Foo: foozle
 }


### PR DESCRIPTION
In many processes that need callback streams, the component that will
consume the callbacks needs some initial configuration during
construction.
This produces a paradox when constructing the New Config callback to
insert into the Params struct.

To resolve this, one have two options:
 - Create a dummy callback with some synchronization and safety-checks
   so one can register the new callback with that other type later.
 - Update Dials so it supports runtime callback registration.

Notably, this implementation uses the new CfgSerial type to provide the
necessary safety-checks and guarantee that if one consumes config
version 3, but while object setup is ongoing, versions 4, 5, and 6 come
along, the callback will only be called with oldCfg from version 3, and
newCfg from version 6.

This guarantees that the callback is called on the latest version at
registration-time.

It's worth noting that since registration and unregistration are done on
the same channel as the event-delivery to the callback manager's
goroutine, we get explicit ordering and before/after relationships, so
we don't need to block on registration.

However, when unregistering, we must block until the unregister is
processed because the unregister event may be queued behind several
new-config events on the channel, which would otherwise be delivered
after the callback is unregistered.

There is one (preexisting) caveat: if we fill up the callback-event
channel (currently statically capacity 64), we drop newer callbacks in
favor of older ones. A future change should introduce some look-aside
saturation handling there.