### PR TITLE
dials/blank: Add/use BlockingReportNewValue

### DIFF
--- a/ez/ez_test.go
+++ b/ez/ez_test.go
@@ -139,7 +139,7 @@ func TestYAMLConfigEnvFlagWithValidatingConfig(t *testing.T) {
 	c := &validatingConfig{Path: path}
 	d, dialsErr := YAMLConfigEnvFlag(ctx, c, Params[validatingConfig]{})
 	assert.NotNil(t, d)
-	require.EqualError(t, dialsErr, "failed to stack/verify config with file layered: val1 789 > 200")
+	require.EqualError(t, dialsErr, "failed to integrate file source: failed to propagate change: stacking failed: val1 789 > 200")
 }
 
 func TestYAMLConfigEnvFlagWithValidatingConfigInitiallyValid(t *testing.T) {
@@ -207,7 +207,7 @@ func TestJSONConfigEnvFlagWithNewConfigCallback(t *testing.T) {
 
 	require.NoError(t, ioutil.WriteFile(path, origJS, 0660))
 
-	newCfg := make(chan interface{}, 1)
+	newCfg := make(chan *validatingConfig, 1)
 	newConfigCB := func(ctx context.Context, oldConfig, newConfig *validatingConfig) {
 		newCfg <- newConfig
 	}
@@ -258,7 +258,7 @@ func TestJSONConfigEnvFlagWithNewConfigCallback(t *testing.T) {
 	expectedFinalConfig.Val1 = updatedCfgContents.Val1
 
 	finalCfg := <-newCfg
-	assert.EqualValues(t, expectedFinalConfig, *finalCfg.(*validatingConfig))
+	assert.EqualValues(t, expectedFinalConfig, *finalCfg)
 
 	finalViewEventCfg := <-view.Events()
 	assert.EqualValues(t, expectedFinalConfig, *finalViewEventCfg)

--- a/sourcewrap/blank.go
+++ b/sourcewrap/blank.go
@@ -112,7 +112,7 @@ func (b *Blank) SetSource(ctx context.Context, s dials.Source) error {
 		return &wrappedErr{prefix: "initial call to Value failed: ", err: err}
 	}
 	b.inner = s
-	if newValErr := b.wa.ReportNewValue(ctx, v); newValErr != nil {
+	if newValErr := b.wa.BlockingReportNewValue(ctx, v); newValErr != nil {
 		return fmt.Errorf("failed to propagate change: %w", newValErr)
 	}
 

--- a/sourcewrap/blank_test.go
+++ b/sourcewrap/blank_test.go
@@ -109,8 +109,8 @@ func TestBlankSource(t *testing.T) {
 		t.Errorf("b.SetSource() failed with trivial nop impl: %s", setErr)
 	}
 
-	// Await the new value, since it's sent asynchronously
-	newConf := <-d.Events()
+	// SetSource should have installed the new version.
+	newConf := d.View()
 	if *newConf != c {
 		t.Errorf("unexpected new config: got %+v; expected %+v", *newConf, c)
 	}
@@ -160,7 +160,7 @@ func TestBlankSourceError(t *testing.T) {
 	// give another goroutine a chance to run before we do a non-blocking read on a channel.
 	runtime.Gosched()
 
-	// make sure nothing comes through on the events channel, sinc our
+	// make sure nothing comes through on the events channel
 	select {
 	case <-d.Events():
 		t.Errorf("unexpected update to view with errored source")
@@ -264,8 +264,8 @@ func TestBlankSourceErrorWatcher(t *testing.T) {
 	}
 
 	{
-		// Await the new value, since it's sent asynchronously
-		newConf := <-d.Events()
+		// Pull the new value (it should be immediately available)
+		newConf := d.View()
 		if *newConf != c {
 			t.Errorf("unexpected new config: got %+v; expected %+v", *newConf, c)
 		}


### PR DESCRIPTION
Blank has been almost impossible to use correctly, with only a few
(constrained) cases where it can be used safely without having terrible
races (hence the complexity in the `ez` package wrapping it).

Fix this by adding a BlockingReportNewValue method to the `WatchArgs`
interface that returns any errors in stacking or validation to the
caller, (and returns successfully if the new config has been
successfully installed)

### ez: simplify impl with blank fixes, cbs & generics
With the last few changes, the building-blocks which ez is wrapping
and/or working with are much more robust and easier to use.

Update ez to reflect this new state:
 - eliminate the extra channels now that Blank blocks and returns
   errors.
 - register the OnNewConfig callback at the end, just before returning.
 - rename `p` to `dp` to eliminate some confusion with `params`