### PR TITLE
Transformer: Construct the right recursive types

### DIFF
--- a/decoders/yaml/yaml_test.go
+++ b/decoders/yaml/yaml_test.go
@@ -87,6 +87,9 @@ func TestShallowlyNestedYAML(t *testing.T) {
 }
 
 func TestMoreDeeplyNestedYAML(t *testing.T) {
+	type innerSliceVal struct {
+		Zizzle string
+	}
 	type testConfig struct {
 		DatabaseName    string `dials:"database_name"`
 		DatabaseAddress string `dials:"database_address"`
@@ -100,6 +103,7 @@ func TestMoreDeeplyNestedYAML(t *testing.T) {
 					Timeout      time.Duration `dials:"timeout"`
 				} `dials:"something"`
 			} `dials:"other_stuff"`
+			SliceThing []innerSliceVal `dials:"slicething"`
 		} `dials:"database_user"`
 	}
 
@@ -113,9 +117,10 @@ func TestMoreDeeplyNestedYAML(t *testing.T) {
 				"something": {
 					"another_field": "asdf",
 					"ip_address": "123.10.11.121",
-					"timeout": "10s", 
+					"timeout": "10s",
 				}
-			}
+			},
+			"slicething": [{"zizzle": "foobar"}, {"zizzle": "fizzlebat"}]
 		}
 	}`
 
@@ -135,6 +140,9 @@ func TestMoreDeeplyNestedYAML(t *testing.T) {
 	assert.Equal(t, "asdf", c.DatabaseUser.OtherStuff.Something.AnotherField)
 	assert.Equal(t, net.IPv4(123, 10, 11, 121), c.DatabaseUser.OtherStuff.Something.IPAddress)
 	assert.Equal(t, time.Duration(10*time.Second), c.DatabaseUser.OtherStuff.Something.Timeout)
+	require.Len(t, c.DatabaseUser.SliceThing, 2)
+	assert.Equal(t, c.DatabaseUser.SliceThing[0].Zizzle, "foobar")
+	assert.Equal(t, c.DatabaseUser.SliceThing[1].Zizzle, "fizzlebat")
 }
 
 func TestDecoderBadMarkup(t *testing.T) {

--- a/transform/transformer_test.go
+++ b/transform/transformer_test.go
@@ -497,10 +497,16 @@ func TestTransformer(t *testing.T) {
 				I: 42,
 			},
 			unmangleVal: struct {
-				J []struct{ L int }
+				J []struct {
+					L int `bizzlebazzle:"foobar"`
+					K int
+				}
 				Q int
 			}{
-				J: []struct{ L int }{{L: 235}},
+				J: []struct {
+					L int `bizzlebazzle:"foobar"`
+					K int
+				}{{L: 235, K: 23}},
 				Q: 88,
 			},
 			fm: fakeMangler{
@@ -516,9 +522,12 @@ func TestTransformer(t *testing.T) {
 					},
 					"J": {
 						{
-							Name:      "J",
-							PkgPath:   "",
-							Type:      reflect.SliceOf(reflect.TypeOf(struct{ L int }{})),
+							Name:    "J",
+							PkgPath: "",
+							Type: reflect.SliceOf(reflect.TypeOf(struct {
+								L int `bizzlebazzle:"foobar"`
+								K int
+							}{})),
 							Tag:       "bizzlebazzle",
 							Anonymous: false,
 						},
@@ -542,6 +551,7 @@ func TestTransformer(t *testing.T) {
 						{L: 255},
 					},
 					"L": 3128,
+					"K": 333,
 				},
 			},
 			expectedMangledFieldNames: []string{
@@ -814,6 +824,7 @@ func TestTransformer(t *testing.T) {
 			}
 			require.NoError(t, mangleErr)
 			require.NotNil(t, mangled)
+			t.Logf("mangled type: %s", mangled)
 
 			require.Equal(t, mangled.NumField(), len(tbl.expectedMangledFieldNames))
 


### PR DESCRIPTION
When recursively unmangling structs with ReverseTransform construct the mangled type for interacting with the intermediate types.

This is a partial revert of 9ffa9007c3918ec9cb214094f6bd9dec7e2bdf2b. I misunderstood the ordering of the code unmangling.

This commit adds a test that creates an incompatible struct for the inner type of a slice (converting from 1 to 2 fields). That test failed in an interesting way, and unmasked my mistake.

In maybeRecursivelyUnmangle the type has to be the mangled type so it can be passed to Unmangle after it's recursed into the fields within that field.

Note: this doesn't trigger in many existing test-cases because the mangled type ends up being assignable to the unmangled type.

This PR also adds some sanity-checks so we return errors rather than panicing within the reflect package in some error-cases. (making it a bit easier to debug)