### PR TITLE
Deterministic Callback Order

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        goversion: [1.18, '1.19.0-rc.1']
+        goversion: [1.18, 1.19]
     steps:
       - name: Set up Go ${{matrix.goversion}} on ${{matrix.os}}
         uses: actions/setup-go@v3


### PR DESCRIPTION
Callbacks were previously stored in a map, which made their execution order undefined.  Instead, store the callbacks in a slice and execute them in the order they were registered.  This has the unfortunate side effect of making callback deregistration O(n) instead of O(1), but that's probably an acceptable tradeoff.

Also, update github actions to build with go 1.19 now that we're passed the release candidate stage.