### PR TITLE
transform: propagate nil slice in SetSliceMangler

### DIFF
--- a/ez/ez_test.go
+++ b/ez/ez_test.go
@@ -166,7 +166,7 @@ func TestYAMLConfigEnvFlagWithValidatingConfigInitiallyValid(t *testing.T) {
 		Path: path,
 		Val1: 189,
 		Val2: "",
-		Set:  map[string]struct{}{},
+		Set:  map[string]struct{}(nil),
 	}
 	populatedConf := view.View()
 	assert.EqualValues(t, expectedConfig, *populatedConf)

--- a/transform/set_slice_mangler.go
+++ b/transform/set_slice_mangler.go
@@ -28,7 +28,7 @@ func (*SetSliceMangler) Mangle(sf reflect.StructField) ([]reflect.StructField, e
 // Unmangle turns []T back into a map[T]struct{}.  Naturally, deduplication will
 // occur.
 func (*SetSliceMangler) Unmangle(sf reflect.StructField, vs []FieldValueTuple) (reflect.Value, error) {
-	if !(sf.Type.Kind() == reflect.Map && sf.Type.Elem() == emptyStructType) {
+	if sf.Type.Kind() != reflect.Map || sf.Type.Elem() != emptyStructType {
 		return vs[0].Value, nil
 	}
 
@@ -47,6 +47,11 @@ func (*SetSliceMangler) Unmangle(sf reflect.StructField, vs []FieldValueTuple) (
 			slice.Type().Elem(),
 			sf.Type.Key(),
 		)
+	}
+
+	// If the slice is nil, return a nil map.
+	if slice.IsZero() {
+		return reflect.Zero(sf.Type), nil
 	}
 
 	// slice.Len() could be larger if there are duplicates, but it's likely

--- a/transform/set_slice_mangler_test.go
+++ b/transform/set_slice_mangler_test.go
@@ -55,6 +55,11 @@ func TestSetSliceManglerUnmangle(t *testing.T) {
 				"baz": {},
 			},
 		},
+		"nil": {
+			StructFieldType: reflect.TypeOf(map[int]struct{}{}),
+			SrcValue:        []int(nil),
+			ExpectedMap:     map[int]struct{}(nil),
+		},
 	}
 
 	for name, c := range cases {


### PR DESCRIPTION
Also address a De Morgan's law nit from staticcheck in the guard

For dials' field-stacking to work, we need nil-slices to convert to nil-maps. Add an explicit check so a nil/missing slice/list doesn't turn into an empty map, which is semantically different in that Dials' stacking code sees empty as "specified, but empty", while nil is interpreted as "unspecified".

As a result, in the former case that field in the config is cleared, and in the latter case it's inheritted from the next layer down. (possibly the default in the template struct)