### PR TITLE
blank: add SetSourceNoVerify

### DIFF
--- a/sourcewrap/blank_test.go
+++ b/sourcewrap/blank_test.go
@@ -3,6 +3,7 @@ package sourcewrap
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"runtime"
 	"testing"
@@ -273,4 +274,115 @@ func TestBlankSourceErrorWatcher(t *testing.T) {
 			t.Errorf("unexpected call-count: %d; expected 1", triv.callCount)
 		}
 	}
+}
+
+type basicConfVerified struct {
+	A int
+	B int
+	C string
+}
+
+func (b basicConfVerified) Verify() error {
+	if b.A < -2 {
+		return fmt.Errorf("value of A is too low: %d (< -2)", b.A)
+	}
+	return nil
+}
+
+// returns an empty value, but increments a counter for every call to Value()
+// (not thread-safe)
+type valuedCountingWatchingSource[V any] struct {
+	callCount   uint32
+	watchcalled bool
+	args        dials.WatchArgs
+	typ         *dials.Type
+	val         V
+}
+
+var _ dials.Watcher = (*valuedCountingWatchingSource[struct{}])(nil)
+
+func (t *valuedCountingWatchingSource[V]) Watch(ctx context.Context, typ *dials.Type, args dials.WatchArgs) error {
+	t.watchcalled = true
+	t.args = args
+	t.typ = typ
+	return nil
+}
+
+func (t *valuedCountingWatchingSource[V]) Value(_ context.Context, typ *dials.Type) (reflect.Value, error) {
+	t.callCount++
+	return reflect.ValueOf(t.val), nil
+}
+
+func (t *valuedCountingWatchingSource[V]) poke(ctx context.Context) {
+	t.args.ReportNewValue(ctx, reflect.New(t.typ.Type()))
+}
+
+func TestBlankSourceWatcherVerifySkip(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	defer cancel()
+	b := Blank{}
+	c := basicConfVerified{
+		A: 3,
+		B: 4809,
+		C: "fob",
+	}
+	d, err := dials.Config(ctx, &c, &b)
+	if err != nil {
+		t.Fatalf("failed to construct View: %s", err)
+	}
+	initConf := d.View()
+	if *initConf != c {
+		t.Errorf("unexpected initial config: got %+v; expected %+v", *initConf, c)
+	}
+
+	type ptredBasicConf struct {
+		A *int
+		B *int
+		C *string
+	}
+	n5val := -5
+	triv := valuedCountingWatchingSource[ptredBasicConf]{
+		val: ptredBasicConf{
+			A: &n5val, // less than the error-threshold
+		},
+	}
+
+	setErr := b.SetSourceSkipVerify(ctx, &triv)
+	if setErr != nil {
+		t.Errorf("b.SetSource() failed with trivial nop impl: %s", setErr)
+	}
+
+	{
+		expConf := basicConfVerified{
+			A: -5,
+			B: 4809,
+			C: "fob",
+		}
+		// Await the new value, since it's sent asynchronously
+		newConf := <-d.Events()
+		if *newConf != expConf {
+			t.Errorf("unexpected new config: got %+v; expected %+v", *newConf, expConf)
+		}
+		if triv.callCount != 1 {
+			t.Errorf("unexpected call-count: %d; expected 1", triv.callCount)
+		}
+	}
+
+	// Poke the the watching source, and verify that we get something back
+	triv.poke(ctx)
+	{
+		// Await the new value, since it's sent asynchronously
+		newConf := <-d.Events()
+		if *newConf != c {
+			t.Errorf("unexpected new config: got %+v; expected %+v", *newConf, c)
+		}
+		if triv.callCount != 1 {
+			t.Errorf("unexpected call-count: %d; expected 1", triv.callCount)
+		}
+		if !triv.watchcalled {
+			t.Errorf("watch not called")
+		}
+	}
+
 }


### PR DESCRIPTION
There are times where one is setting multiple sources, and the intermediate stages (with only a subset of sources installed) fails the config's Verify() method. Make it possible for callers to explicitly skip verification when setting a new blank source in the cases where it's needed.

This is not expected to be a common case, but there are situations where there are multiple configuration files that need to all be processed (possibly in a specific order) before the configuration will become valid.

It is unlikely that any watching sources besides the blank source will need to use the new BlockingReportNewValueSkipValue, but it is now part of the public API so Blank is not _that_ special.