### PR TITLE
dials: add DelayInitialVerification mode

### DIFF
--- a/cb_mgr.go
+++ b/cb_mgr.go
@@ -18,6 +18,7 @@ type userCallbackEvent interface {
 type newConfigEvent[T any] struct {
 	oldConfig, newConfig *T
 	serial               uint64
+	globalCBsSuppressed  bool
 }
 
 func (*newConfigEvent[T]) isUserCallbackEvent() {}
@@ -75,7 +76,7 @@ func (cbm *callbackMgr[T]) runCBs(ctx context.Context) {
 		case *newConfigEvent[T]:
 			lastSerial = e.serial
 			lastVersion = e.newConfig
-			if cbm.p.OnNewConfig != nil {
+			if cbm.p.OnNewConfig != nil && !e.globalCBsSuppressed {
 				cbm.p.OnNewConfig(ctx, e.oldConfig, e.newConfig)
 			}
 			for _, cbh := range newCfgCBs {

--- a/dials_118.go
+++ b/dials_118.go
@@ -12,6 +12,7 @@ type Dials[T any] struct {
 	updatesChan chan *T
 	params      Params[T]
 	cbch        chan<- userCallbackEvent
+	monCtl      chan<- verifyEnable[T]
 }
 
 // View returns the configuration struct populated.

--- a/dials_119.go
+++ b/dials_119.go
@@ -12,6 +12,7 @@ type Dials[T any] struct {
 	updatesChan chan *T
 	params      Params[T]
 	cbch        chan<- userCallbackEvent
+	monCtl      chan<- verifyEnable[T]
 }
 
 // View returns the configuration struct populated.


### PR DESCRIPTION
Add a way to delay the initial Verify() call, so users can do multi-step initialization which have intermediate states that are not guaranteed to pass the Verify() method (usually involving multiple blank sources).

After initialization is complete, the user can call VerifyEnable() to get the current config and enable verification.