### PR TITLE
Fix Custom Type Handling

### DIFF
--- a/sources/flag/flag.go
+++ b/sources/flag/flag.go
@@ -27,6 +27,28 @@ var (
 	stringSet            = reflect.MapOf(reflect.TypeOf(""), reflect.TypeOf(struct{}{}))
 	textMReflectType     = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
 
+	stringType = reflect.TypeOf("")
+
+	boolType = reflect.TypeOf(false)
+
+	float32Type = reflect.TypeOf(float32(0))
+	float64Type = reflect.TypeOf(float64(0))
+
+	intType   = reflect.TypeOf(int(0))
+	int8Type  = reflect.TypeOf(int8(0))
+	int16Type = reflect.TypeOf(int16(0))
+	int32Type = reflect.TypeOf(int32(0))
+	int64Type = reflect.TypeOf(int64(0))
+
+	uintType   = reflect.TypeOf(uint(0))
+	uint8Type  = reflect.TypeOf(uint8(0))
+	uint16Type = reflect.TypeOf(uint16(0))
+	uint32Type = reflect.TypeOf(uint32(0))
+	uint64Type = reflect.TypeOf(uint64(0))
+
+	complex64Type  = reflect.TypeOf((*complex64)(nil))
+	complex128Type = reflect.TypeOf((*complex128)(nil))
+
 	// Verify that Set implements the dials.Source interface
 	_ dials.Source = (*Set)(nil)
 )
@@ -251,57 +273,37 @@ func (s *Set) registerFlags(tmpl reflect.Value, ptyp reflect.Type) error {
 
 		switch k {
 		case reflect.String:
-			s.Flags.String(name, fieldVal.Interface().(string), help)
+			s.Flags.String(name, fieldVal.Convert(stringType).Interface().(string), help)
 		case reflect.Bool:
-			s.Flags.Bool(name, fieldVal.Interface().(bool), help)
+			s.Flags.Bool(name, fieldVal.Convert(boolType).Interface().(bool), help)
 		case reflect.Float64:
-			s.Flags.Float64(name, fieldVal.Interface().(float64), help)
+			s.Flags.Float64(name, fieldVal.Convert(float64Type).Interface().(float64), help)
 		case reflect.Float32:
-			s.Flags.Float64(name, float64(fieldVal.Interface().(float32)), help)
+			s.Flags.Float64(name, float64(fieldVal.Convert(float32Type).Interface().(float32)), help)
 		case reflect.Complex64:
-			s.Flags.Var(flaghelper.NewComplex64Var(fieldVal.Addr().Interface().(*complex64)), name, help)
+			s.Flags.Var(flaghelper.NewComplex64Var(fieldVal.Addr().Convert(complex64Type).Interface().(*complex64)), name, help)
 		case reflect.Complex128:
-			s.Flags.Var(flaghelper.NewComplex128Var(fieldVal.Addr().Interface().(*complex128)), name, help)
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
-			{
-				fvToInt := func() int {
-					switch v := fieldVal.Interface().(type) {
-					case int:
-						return v
-					case int8:
-						return int(v)
-					case int16:
-						return int(v)
-					case int32:
-						return int(v)
-					default:
-						return 0
-					}
-				}
-				s.Flags.Int(name, fvToInt(), help)
-			}
+			s.Flags.Var(flaghelper.NewComplex128Var(fieldVal.Addr().Convert(complex128Type).Interface().(*complex128)), name, help)
+		case reflect.Int:
+			s.Flags.Int(name, fieldVal.Convert(intType).Interface().(int), help)
+		case reflect.Int8:
+			s.Flags.Int(name, int(fieldVal.Convert(int8Type).Interface().(int8)), help)
+		case reflect.Int16:
+			s.Flags.Int(name, int(fieldVal.Convert(int16Type).Interface().(int16)), help)
+		case reflect.Int32:
+			s.Flags.Int(name, int(fieldVal.Convert(int32Type).Interface().(int32)), help)
 		case reflect.Int64:
-			s.Flags.Int64(name, fieldVal.Int(), help)
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32:
-			{
-				fvToInt := func() uint {
-					switch v := fieldVal.Interface().(type) {
-					case uint:
-						return v
-					case uint8:
-						return uint(v)
-					case uint16:
-						return uint(v)
-					case uint32:
-						return uint(v)
-					default:
-						return 0
-					}
-				}
-				s.Flags.Uint(name, fvToInt(), help)
-			}
+			s.Flags.Int64(name, fieldVal.Convert(int64Type).Int(), help)
+		case reflect.Uint:
+			s.Flags.Uint(name, fieldVal.Convert(uintType).Interface().(uint), help)
+		case reflect.Uint8:
+			s.Flags.Uint(name, uint(fieldVal.Convert(uint8Type).Interface().(uint8)), help)
+		case reflect.Uint16:
+			s.Flags.Uint(name, uint(fieldVal.Convert(uint16Type).Interface().(uint16)), help)
+		case reflect.Uint32:
+			s.Flags.Uint(name, uint(fieldVal.Convert(uint32Type).Interface().(uint32)), help)
 		case reflect.Uint64:
-			s.Flags.Uint64(name, fieldVal.Interface().(uint64), help)
+			s.Flags.Uint64(name, fieldVal.Convert(uint64Type).Interface().(uint64), help)
 		case reflect.Slice, reflect.Map:
 			switch ft {
 			case stringSlice:

--- a/sources/flag/flag_test.go
+++ b/sources/flag/flag_test.go
@@ -36,7 +36,7 @@ func TestDirectBasic(t *testing.T) {
 	buf := &bytes.Buffer{}
 	src.Flags.SetOutput(buf)
 
-	d, err := dials.Config(ctx, &Config{}, src)
+	d, err := dials.Config(ctx, &Config{Hello: "nothing"}, src)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,6 +62,91 @@ func TestDirectBasic(t *testing.T) {
 
 	if got.SomeTime != 2*time.Second {
 		t.Errorf("expected SomeTime to be 2s, got %s", got.SomeTime)
+	}
+}
+
+func TestDefaultVals(t *testing.T) {
+	type otherString string
+	type otherBool bool
+	type otherInt int
+	type otherInt8 int8
+	type otherInt16 int16
+	type otherInt32 int32
+	type otherInt64 int64
+	type otherUint uint
+	type otherUint8 uint8
+	type otherUint16 uint16
+	type otherUint32 uint32
+	type otherUint64 uint64
+	type otherFloat32 float32
+	type otherFloat64 float64
+	type otherComplex64 complex64
+	type otherComplex128 complex128
+
+	type config struct {
+		OString     otherString
+		OBool       otherBool
+		OInt        otherInt
+		OInt8       otherInt8
+		OInt16      otherInt16
+		OInt32      otherInt32
+		OInt64      otherInt64
+		OUint       otherUint
+		OUint8      otherUint8
+		OUint16     otherUint16
+		OUint32     otherUint32
+		OUint64     otherUint64
+		OFloat32    otherFloat32
+		OFloat64    otherFloat64
+		OComplex64  otherComplex64
+		OComplex128 otherComplex128
+	}
+
+	c := config{
+		OString:     "a-string",
+		OBool:       true,
+		OInt:        -1,
+		OInt8:       -2,
+		OInt16:      -3,
+		OInt32:      -4,
+		OInt64:      -5,
+		OUint:       1,
+		OUint8:      2,
+		OUint16:     3,
+		OUint32:     4,
+		OUint64:     5,
+		OFloat32:    6.0,
+		OFloat64:    7.0,
+		OComplex64:  8 + 2i,
+		OComplex128: 9 + 3i,
+	}
+
+	expected := c
+	t.Logf("expected: %+v", expected)
+
+	fs := flag.NewFlagSet("test flags", flag.ContinueOnError)
+	src := &Set{
+		Flags: fs,
+		ParseFunc: func() error {
+			// don't need to parse any flags because we're only interested in
+			// checking the default setting with these custom types.
+			return fs.Parse([]string{})
+		},
+	}
+	buf := &bytes.Buffer{}
+	src.Flags.SetOutput(buf)
+
+	d, err := dials.Config(context.Background(), &c, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src.Flags.Usage()
+	t.Log(buf.String())
+
+	got := d.View()
+	t.Logf("got: %+v", got)
+	if *got != expected {
+		t.Errorf("wanted %+v got %+v", expected, got)
 	}
 }
 

--- a/sources/flag/flaghelper/complex.go
+++ b/sources/flag/flaghelper/complex.go
@@ -34,6 +34,9 @@ func (v *Complex128Var) Get() interface{} {
 
 // String implements flag.Value and pflag.Value
 func (v *Complex128Var) String() string {
+	if v.c == nil {
+		return ""
+	}
 	return fmt.Sprintf("%g", *v.c)
 }
 
@@ -70,6 +73,9 @@ func (v *Complex64Var) Get() interface{} {
 
 // String implements flag.Value and pflag.Value
 func (v *Complex64Var) String() string {
+	if v.c == nil {
+		return ""
+	}
 	return fmt.Sprintf("%g", *v.c)
 }
 

--- a/sources/pflag/pflag.go
+++ b/sources/pflag/pflag.go
@@ -29,6 +29,28 @@ var (
 	mapStringString      = reflect.MapOf(reflect.TypeOf(""), reflect.TypeOf(""))
 	stringSet            = reflect.MapOf(reflect.TypeOf(""), reflect.TypeOf(struct{}{}))
 
+	stringType = reflect.TypeOf("")
+
+	boolType = reflect.TypeOf(false)
+
+	float32Type = reflect.TypeOf(float32(0))
+	float64Type = reflect.TypeOf(float64(0))
+
+	intType   = reflect.TypeOf(int(0))
+	int8Type  = reflect.TypeOf(int8(0))
+	int16Type = reflect.TypeOf(int16(0))
+	int32Type = reflect.TypeOf(int32(0))
+	int64Type = reflect.TypeOf(int64(0))
+
+	uintType   = reflect.TypeOf(uint(0))
+	uint8Type  = reflect.TypeOf(uint8(0))
+	uint16Type = reflect.TypeOf(uint16(0))
+	uint32Type = reflect.TypeOf(uint32(0))
+	uint64Type = reflect.TypeOf(uint64(0))
+
+	complex64Type  = reflect.TypeOf((*complex64)(nil))
+	complex128Type = reflect.TypeOf((*complex128)(nil))
+
 	// Verify that Set implements the dials.Source interface
 	_ dials.Source = (*Set)(nil)
 )
@@ -258,39 +280,39 @@ func (s *Set) registerFlags(tmpl reflect.Value, ptyp reflect.Type) error {
 
 		switch k {
 		case reflect.String:
-			f = s.Flags.StringP(name, shorthand, fieldVal.Interface().(string), help)
+			f = s.Flags.StringP(name, shorthand, fieldVal.Convert(stringType).Interface().(string), help)
 		case reflect.Bool:
-			f = s.Flags.BoolP(name, shorthand, fieldVal.Interface().(bool), help)
+			f = s.Flags.BoolP(name, shorthand, fieldVal.Convert(boolType).Interface().(bool), help)
 		case reflect.Float64:
-			f = s.Flags.Float64P(name, shorthand, fieldVal.Interface().(float64), help)
+			f = s.Flags.Float64P(name, shorthand, fieldVal.Convert(float64Type).Interface().(float64), help)
 		case reflect.Float32:
-			f = s.Flags.Float32P(name, shorthand, fieldVal.Interface().(float32), help)
+			f = s.Flags.Float32P(name, shorthand, fieldVal.Convert(float32Type).Interface().(float32), help)
 		case reflect.Complex64:
 			f = fieldVal.Addr().Interface()
-			s.Flags.VarP(flaghelper.NewComplex64Var(fieldVal.Addr().Interface().(*complex64)), name, shorthand, help)
+			s.Flags.VarP(flaghelper.NewComplex64Var(fieldVal.Addr().Convert(complex64Type).Interface().(*complex64)), name, shorthand, help)
 		case reflect.Complex128:
 			f = fieldVal.Addr().Interface()
-			s.Flags.VarP(flaghelper.NewComplex128Var(fieldVal.Addr().Interface().(*complex128)), name, shorthand, help)
+			s.Flags.VarP(flaghelper.NewComplex128Var(fieldVal.Addr().Convert(complex128Type).Interface().(*complex128)), name, shorthand, help)
 		case reflect.Int:
-			f = s.Flags.IntP(name, shorthand, fieldVal.Interface().(int), help)
+			f = s.Flags.IntP(name, shorthand, fieldVal.Convert(intType).Interface().(int), help)
 		case reflect.Int8:
-			f = s.Flags.Int8P(name, shorthand, fieldVal.Interface().(int8), help)
+			f = s.Flags.Int8P(name, shorthand, fieldVal.Convert(int8Type).Interface().(int8), help)
 		case reflect.Int16:
-			f = s.Flags.Int16P(name, shorthand, fieldVal.Interface().(int16), help)
+			f = s.Flags.Int16P(name, shorthand, fieldVal.Convert(int16Type).Interface().(int16), help)
 		case reflect.Int32:
-			f = s.Flags.Int32P(name, shorthand, fieldVal.Interface().(int32), help)
+			f = s.Flags.Int32P(name, shorthand, fieldVal.Convert(int32Type).Interface().(int32), help)
 		case reflect.Int64:
-			f = s.Flags.Int64P(name, shorthand, fieldVal.Int(), help)
+			f = s.Flags.Int64P(name, shorthand, fieldVal.Convert(int64Type).Int(), help)
 		case reflect.Uint:
-			f = s.Flags.UintP(name, shorthand, fieldVal.Interface().(uint), help)
+			f = s.Flags.UintP(name, shorthand, fieldVal.Convert(uintType).Interface().(uint), help)
 		case reflect.Uint8:
-			f = s.Flags.Uint8P(name, shorthand, fieldVal.Interface().(uint8), help)
+			f = s.Flags.Uint8P(name, shorthand, fieldVal.Convert(uint8Type).Interface().(uint8), help)
 		case reflect.Uint16:
-			f = s.Flags.Uint16P(name, shorthand, fieldVal.Interface().(uint16), help)
+			f = s.Flags.Uint16P(name, shorthand, fieldVal.Convert(uint16Type).Interface().(uint16), help)
 		case reflect.Uint32:
-			f = s.Flags.Uint32P(name, shorthand, fieldVal.Interface().(uint32), help)
+			f = s.Flags.Uint32P(name, shorthand, fieldVal.Convert(uint32Type).Interface().(uint32), help)
 		case reflect.Uint64:
-			f = s.Flags.Uint64P(name, shorthand, fieldVal.Interface().(uint64), help)
+			f = s.Flags.Uint64P(name, shorthand, fieldVal.Convert(uint64Type).Interface().(uint64), help)
 		case reflect.Slice, reflect.Map:
 			switch ft {
 			case stringSlice:

--- a/sources/pflag/pflag_test.go
+++ b/sources/pflag/pflag_test.go
@@ -68,6 +68,91 @@ func TestDirectBasicPFlag(t *testing.T) {
 	}
 }
 
+func TestDefaultVals(t *testing.T) {
+	type otherString string
+	type otherBool bool
+	type otherInt int
+	type otherInt8 int8
+	type otherInt16 int16
+	type otherInt32 int32
+	type otherInt64 int64
+	type otherUint uint
+	type otherUint8 uint8
+	type otherUint16 uint16
+	type otherUint32 uint32
+	type otherUint64 uint64
+	type otherFloat32 float32
+	type otherFloat64 float64
+	type otherComplex64 complex64
+	type otherComplex128 complex128
+
+	type config struct {
+		OString     otherString
+		OBool       otherBool
+		OInt        otherInt
+		OInt8       otherInt8
+		OInt16      otherInt16
+		OInt32      otherInt32
+		OInt64      otherInt64
+		OUint       otherUint
+		OUint8      otherUint8
+		OUint16     otherUint16
+		OUint32     otherUint32
+		OUint64     otherUint64
+		OFloat32    otherFloat32
+		OFloat64    otherFloat64
+		OComplex64  otherComplex64
+		OComplex128 otherComplex128
+	}
+
+	c := config{
+		OString:     "a-string",
+		OBool:       true,
+		OInt:        -1,
+		OInt8:       -2,
+		OInt16:      -3,
+		OInt32:      -4,
+		OInt64:      -5,
+		OUint:       1,
+		OUint8:      2,
+		OUint16:     3,
+		OUint32:     4,
+		OUint64:     5,
+		OFloat32:    6.0,
+		OFloat64:    7.0,
+		OComplex64:  8 + 2i,
+		OComplex128: 9 + 3i,
+	}
+
+	expected := c
+
+	fs := pflag.NewFlagSet("test flags", pflag.ContinueOnError)
+	fs.Usage = pflag.Usage
+	src := &Set{
+		Flags: fs,
+		ParseFunc: func() error {
+			// don't need to parse any flags because we're only interested in
+			// checking the default setting with these custom types.
+			return fs.Parse([]string{})
+		},
+	}
+	buf := &bytes.Buffer{}
+	src.Flags.SetOutput(buf)
+
+	d, err := dials.Config(context.Background(), &c, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src.Flags.Usage()
+	t.Log(buf.String())
+
+	got := d.View()
+
+	if *got != expected {
+		t.Errorf("wanted %+v got %+v", expected, got)
+	}
+}
+
 type tu struct {
 	Text string
 }


### PR DESCRIPTION
When using something like `type MyString string` we need to make sure to convert it to the proper underlying type before sending it on to the flag package.

Fix this for both the flag and pflag packages.