### PR TITLE
Fix staticcheck Warnings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/pelletier/go-toml v1.6.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
+	golang.org/x/text v0.3.7
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -21,6 +22,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b // indirect
 	golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d // indirect
-	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/parse/number.go
+++ b/parse/number.go
@@ -30,7 +30,7 @@ func parseNumber(strVal string, numberType reflect.Type) (reflect.Value, error) 
 		// Check for overflow
 		convertTo := reflect.Zero(numberType)
 		if convertTo.OverflowInt(converted) {
-			return reflect.Value{}, &OverflowError{err: fmt.Errorf("Overflow of %v type: %v", numberType, converted)}
+			return reflect.Value{}, &OverflowError{err: fmt.Errorf("overflow of %v type: %v", numberType, converted)}
 		}
 
 		switch numberType.Kind() {
@@ -59,7 +59,7 @@ func parseNumber(strVal string, numberType reflect.Type) (reflect.Value, error) 
 		// Check for overflow
 		convertTo := reflect.Zero(numberType)
 		if convertTo.OverflowUint(converted) {
-			return reflect.Value{}, &OverflowError{err: fmt.Errorf("Overflow of %v type: %v", numberType, converted)}
+			return reflect.Value{}, &OverflowError{err: fmt.Errorf("overflow of %v type: %v", numberType, converted)}
 		}
 
 		switch numberType.Kind() {
@@ -88,7 +88,7 @@ func parseNumber(strVal string, numberType reflect.Type) (reflect.Value, error) 
 		// Check for overflow
 		convertTo := reflect.Zero(numberType)
 		if convertTo.OverflowFloat(converted) {
-			return reflect.Value{}, &OverflowError{err: fmt.Errorf("Overflow of %v type: %v", numberType, converted)}
+			return reflect.Value{}, &OverflowError{err: fmt.Errorf("overflow of %v type: %v", numberType, converted)}
 		}
 
 		fl32 := float32(converted)
@@ -102,7 +102,7 @@ func parseNumber(strVal string, numberType reflect.Type) (reflect.Value, error) 
 		// Check for overflow
 		convertTo := reflect.Zero(numberType)
 		if convertTo.OverflowFloat(converted) {
-			return reflect.Value{}, &OverflowError{err: fmt.Errorf("Overflow of %v type: %v", numberType, converted)}
+			return reflect.Value{}, &OverflowError{err: fmt.Errorf("overflow of %v type: %v", numberType, converted)}
 		}
 
 		castVal = reflect.ValueOf(&converted)
@@ -115,7 +115,7 @@ func parseNumber(strVal string, numberType reflect.Type) (reflect.Value, error) 
 		// Check for overflow
 		convertTo := reflect.Zero(numberType)
 		if convertTo.OverflowComplex(complex128(converted)) {
-			return reflect.Value{}, &OverflowError{err: fmt.Errorf("Overflow of %v type: %v", numberType, converted)}
+			return reflect.Value{}, &OverflowError{err: fmt.Errorf("overflow of %v type: %v", numberType, converted)}
 		}
 
 		castVal = reflect.ValueOf(&converted)
@@ -128,7 +128,7 @@ func parseNumber(strVal string, numberType reflect.Type) (reflect.Value, error) 
 		// Check for overflow
 		convertTo := reflect.Zero(numberType)
 		if convertTo.OverflowComplex(converted) {
-			return reflect.Value{}, &OverflowError{err: fmt.Errorf("Overflow of %v type: %v", numberType, converted)}
+			return reflect.Value{}, &OverflowError{err: fmt.Errorf("overflow of %v type: %v", numberType, converted)}
 		}
 
 		castVal = reflect.ValueOf(&converted)

--- a/parse/parse_string.go
+++ b/parse/parse_string.go
@@ -6,24 +6,6 @@ import (
 	"strconv"
 )
 
-var (
-	stringSliceType     = reflect.TypeOf([]string{})
-	boolSliceType       = reflect.TypeOf([]bool{})
-	intSliceType        = reflect.TypeOf([]int{})
-	int8SliceType       = reflect.TypeOf([]int8{})
-	int16SliceType      = reflect.TypeOf([]int16{})
-	int32SliceType      = reflect.TypeOf([]int32{})
-	int64SliceType      = reflect.TypeOf([]int64{})
-	uintSliceType       = reflect.TypeOf([]uint{})
-	uint8SliceType      = reflect.TypeOf([]uint8{})
-	uint16SliceType     = reflect.TypeOf([]uint16{})
-	uint32SliceType     = reflect.TypeOf([]uint32{})
-	float32SliceType    = reflect.TypeOf([]float32{})
-	float64SliceType    = reflect.TypeOf([]float64{})
-	complex64SliceType  = reflect.TypeOf([]complex64{})
-	complex128SliceType = reflect.TypeOf([]complex128{})
-)
-
 // String casts the provided string into the provided type, returning the
 // result in a reflect.Value.
 func String(str string, t reflect.Type) (reflect.Value, error) {
@@ -79,7 +61,7 @@ func String(str string, t reflect.Type) (reflect.Value, error) {
 			valKind := t.Elem().Kind()
 			err := checkKindsSupported(keyKind, valKind)
 			if err != nil {
-				return reflect.Value{}, fmt.Errorf("Unsupported map type: %v", t)
+				return reflect.Value{}, fmt.Errorf("unsupported map type: %v", t)
 			}
 			converted, err := Map(str, t)
 			if err != nil {
@@ -89,7 +71,7 @@ func String(str string, t reflect.Type) (reflect.Value, error) {
 		}
 	default:
 		// If the type of the original StructField is unsupported, return an error.
-		return reflect.Value{}, fmt.Errorf("Value %q cannot be translated to kind %q", str, t.Kind())
+		return reflect.Value{}, fmt.Errorf("value %q cannot be translated to kind %q", str, t.Kind())
 	}
 }
 
@@ -103,7 +85,7 @@ func checkKindsSupported(kinds ...reflect.Kind) error {
 			reflect.Complex128:
 			// no-op
 		default:
-			return fmt.Errorf("Kind %v not supported", k)
+			return fmt.Errorf("kind %v not supported", k)
 		}
 	}
 	return nil

--- a/ptrify/ptrify_test.go
+++ b/ptrify/ptrify_test.go
@@ -10,9 +10,7 @@ import (
 
 func TestPointerify(t *testing.T) {
 	type sInt struct{ J int }
-	type sBool struct{ J bool }
 	type sIntPtr struct{ J *int }
-	type sBoolPtr struct{ J *bool }
 
 	for name, inst := range map[string]struct {
 		i        interface{}

--- a/sources/env/env.go
+++ b/sources/env/env.go
@@ -53,7 +53,7 @@ func (e *Source) Value(_ context.Context, t *dials.Type) (reflect.Value, error) 
 		if envTagVal == "" {
 			// dialsenv tag should be populated because dials tag is populated
 			// after flatten mangler and we copy from dials to dialsenv tag
-			panic(fmt.Errorf("Empty %s tag for field name %s", envTagName, sf.Name))
+			panic(fmt.Errorf("empty %s tag for field name %s", envTagName, sf.Name))
 		}
 
 		if e.Prefix != "" {

--- a/sources/env/env_test.go
+++ b/sources/env/env_test.go
@@ -100,7 +100,7 @@ func TestEnv(t *testing.T) {
 			EnvVarName:  "ENV_VAR",
 			EnvVarValue: "999999",
 			Expected:    nil,
-			ExpectedErr: "Overflow of int8 type: 999999",
+			ExpectedErr: "overflow of int8 type: 999999",
 		},
 		"bool": {
 			Run: func(ctx context.Context, src *Source) (any, error) {

--- a/sources/flag/flag.go
+++ b/sources/flag/flag.go
@@ -148,7 +148,7 @@ func NewSetWithArgs(cfg *NameConfig, template interface{}, args []string) (*Set,
 //	var flagset = flag.Must(flag.NewCmdLineSet(flag.DefaultFlagNameConfig(), config))
 func Must(s *Set, err error) *Set {
 	if err != nil {
-		panic(fmt.Errorf("Error registering flags: %w", err))
+		panic(fmt.Errorf("error registering flags: %w", err))
 	}
 	return s
 }
@@ -385,7 +385,7 @@ func (s *Set) Value(_ context.Context, t *dials.Type) (reflect.Value, error) {
 		if !ffield.IsNil() {
 			// there's a 1:1 mapping between flags and field names so panic if
 			// this happens
-			panic(fmt.Errorf("Field name %s with flag %s is nil", fieldName, f.Name))
+			panic(fmt.Errorf("field name %s with flag %s is nil", fieldName, f.Name))
 		}
 
 		// We'll assume we're in a pointerified struct that matches
@@ -422,7 +422,6 @@ func (s *Set) Value(_ context.Context, t *dials.Type) (reflect.Value, error) {
 		default:
 			ffield.Set(cfval)
 		}
-		return
 	})
 	if setErr != nil {
 		return val.Elem(), setErr
@@ -475,6 +474,6 @@ func (s *Set) mkname(sf reflect.StructField) string {
 
 	// panic because flatten mangler should set the dials tag so panic if that
 	// wasn't set
-	panic(fmt.Errorf("Expected dials tag name for struct field %q", sf.Name))
+	panic(fmt.Errorf("expected dials tag name for struct field %q", sf.Name))
 
 }

--- a/sources/flag/flag_test.go
+++ b/sources/flag/flag_test.go
@@ -156,7 +156,7 @@ type tu struct {
 
 // need a concrete type that implements TextUnmarshaler
 func (u tu) UnmarshalText(data []byte) error {
-	u.Text = string(data)
+	u.Text = string(data) //lint:ignore SA4005 we purposely don't want this to work
 	return nil
 }
 

--- a/sources/pflag/pflag.go
+++ b/sources/pflag/pflag.go
@@ -138,7 +138,7 @@ func NewDefaultSetWithFlagSet(template interface{}, flagset *pflag.FlagSet) (*Se
 //	var flagset = pflag.Must(pflag.NewCmdLineSet(pflag.DefaultFlagNameConfig(), config))
 func Must(s *Set, err error) *Set {
 	if err != nil {
-		panic(fmt.Errorf("Error registering flags: %w", err))
+		panic(fmt.Errorf("error registering flags: %w", err))
 	}
 	return s
 }
@@ -405,7 +405,7 @@ func (s *Set) Value(_ context.Context, t *dials.Type) (reflect.Value, error) {
 		if !ffield.IsNil() {
 			// there's a 1:1 mapping between flags and field names so panic if
 			// this happens
-			panic(fmt.Errorf("Field name %s with flag %s is nil", fieldName, f.Name))
+			panic(fmt.Errorf("field name %s with flag %s is nil", fieldName, f.Name))
 		}
 
 		// We'll assume we're in a pointerified struct that matches
@@ -438,7 +438,6 @@ func (s *Set) Value(_ context.Context, t *dials.Type) (reflect.Value, error) {
 		default:
 			ffield.Set(cfval)
 		}
-		return
 	})
 	if setErr != nil {
 		return val.Elem(), setErr
@@ -471,6 +470,6 @@ func (s *Set) mkname(sf reflect.StructField) string {
 
 	// panic because flatten mangler should set the dials tag so panic if that
 	// wasn't set
-	panic(fmt.Errorf("Expected dials tag name for struct field %q", sf.Name))
+	panic(fmt.Errorf("expected dials tag name for struct field %q", sf.Name))
 
 }

--- a/sources/pflag/pflag_test.go
+++ b/sources/pflag/pflag_test.go
@@ -159,7 +159,7 @@ type tu struct {
 
 // need a concrete type that implements TextUnmarshaler
 func (u tu) UnmarshalText(data []byte) error {
-	u.Text = string(data)
+	u.Text = string(data) //lint:ignore SA4005 we purposely don't want this to work
 	return nil
 }
 

--- a/tagformat/caseconversion/case_conversion.go
+++ b/tagformat/caseconversion/case_conversion.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // DecodeCasingFunc takes in an identifier in a case such as camelCase or
@@ -27,13 +30,13 @@ func decodeCamelCase(typeName, s string) (DecodedIdentifier, error) {
 	// ignore the size of the rune
 	r, _ := utf8.DecodeRuneInString(s)
 	if r == utf8.RuneError || unicode.IsDigit(r) {
-		return nil, fmt.Errorf("Converting case of %q: %s strings can't start with characters of the Decimal Digit category", s, typeName)
+		return nil, fmt.Errorf("converting case of %q: %s strings can't start with characters of the Decimal Digit category", s, typeName)
 	}
 	words := []string{}
 	lastBoundary := 0
 	for z, char := range s {
 		if !unicode.IsLetter(char) && !unicode.IsDigit(char) {
-			return nil, fmt.Errorf("Converting case of %q: Only characters of the Letter and Decimal Digit categories can appear in %s strings: %c at byte offset %d",
+			return nil, fmt.Errorf("converting case of %q: Only characters of the Letter and Decimal Digit categories can appear in %s strings: %c at byte offset %d",
 				s, typeName, char, z)
 		}
 		if unicode.IsUpper(char) {
@@ -54,7 +57,7 @@ func DecodeUpperCamelCase(s string) (DecodedIdentifier, error) {
 	// ignore the size of the rune
 	r, _ := utf8.DecodeRuneInString(s)
 	if !unicode.IsLetter(r) || !unicode.IsUpper(r) {
-		return nil, fmt.Errorf("Converting case of %q: First character of upperCamelCase string must be an uppercase character of the Letter category", s)
+		return nil, fmt.Errorf("converting case of %q: First character of upperCamelCase string must be an uppercase character of the Letter category", s)
 	}
 	return decodeCamelCase("UpperCamelCase", s)
 }
@@ -64,7 +67,7 @@ func DecodeLowerCamelCase(s string) (DecodedIdentifier, error) {
 	// ignore the size of the rune
 	r, _ := utf8.DecodeRuneInString(s)
 	if !unicode.IsLetter(r) || !unicode.IsLower(r) {
-		return nil, fmt.Errorf("Converting case of %q: First character of lowerCamelCase string must be a lowercase character of the Letter category", s)
+		return nil, fmt.Errorf("converting case of %q: First character of lowerCamelCase string must be a lowercase character of the Letter category", s)
 	}
 	return decodeCamelCase("lowerCamelCase", s)
 }
@@ -155,7 +158,7 @@ func decodeGoCamelCase(s string, isWordBoundary func(rune) bool) (DecodedIdentif
 // sub-strings.
 func DecodeGoCamelCase(s string) (DecodedIdentifier, error) {
 	if !token.IsIdentifier(s) {
-		return nil, fmt.Errorf("Only characters of the Letter category or '_' can appear in strings")
+		return nil, fmt.Errorf("only characters of the Letter category or '_' can appear in strings")
 	}
 	return decodeGoCamelCase(s, func(r rune) bool {
 		return r == '_'
@@ -202,7 +205,7 @@ func decodeLowerCaseWithSplitChar(splitChar rune, typeName, s string) (DecodedId
 	// ignore the size of the rune
 	r, _ := utf8.DecodeRuneInString(s)
 	if r == utf8.RuneError || unicode.IsDigit(r) {
-		return nil, fmt.Errorf("Converting case of %q: %s strings can't start with characters of the Decimal Digit category", s, typeName)
+		return nil, fmt.Errorf("converting case of %q: %s strings can't start with characters of the Decimal Digit category", s, typeName)
 	}
 
 	words := []string{}
@@ -215,7 +218,7 @@ func decodeLowerCaseWithSplitChar(splitChar rune, typeName, s string) (DecodedId
 			}
 			lastBoundary = z + utf8.RuneLen(splitChar)
 		} else if (!unicode.IsLetter(char) && !unicode.IsDigit(char)) || (!unicode.IsLower(char) && !unicode.IsDigit(char)) {
-			return nil, fmt.Errorf("Converting case of %q: Only lower-case letter-category characters, digits, and '%c' can appear in `%s` strings: %c at byte-offset %d does not comply", s, splitChar, typeName, char, z)
+			return nil, fmt.Errorf("converting case of %q: Only lower-case letter-category characters, digits, and '%c' can appear in `%s` strings: %c at byte-offset %d does not comply", s, splitChar, typeName, char, z)
 		}
 	}
 	// flush one last time to get the remainder of the string
@@ -241,7 +244,7 @@ func DecodeUpperSnakeCase(s string) (DecodedIdentifier, error) {
 	// ignore the size of the rune
 	r, _ := utf8.DecodeRuneInString(s)
 	if r == utf8.RuneError || unicode.IsDigit(r) {
-		return nil, fmt.Errorf("Converting case of %q: UPPER_SNAKE_CASE strings can't start with characters of the Decimal Digit category", s)
+		return nil, fmt.Errorf("converting case of %q: UPPER_SNAKE_CASE strings can't start with characters of the Decimal Digit category", s)
 	}
 
 	words := []string{}
@@ -254,7 +257,7 @@ func DecodeUpperSnakeCase(s string) (DecodedIdentifier, error) {
 			}
 			lastBoundary = z + 1
 		} else if (!unicode.IsLetter(char) && !unicode.IsDigit(char)) || (!unicode.IsUpper(char) && !unicode.IsDigit(char)) {
-			return nil, fmt.Errorf("Converting case of %q: Only uppercase characters of the Letter category and '_' can appear in UPPER_SNAKE_CASE strings: %c in at byte-offset %d does not comply", s, char, z)
+			return nil, fmt.Errorf("converting case of %q: Only uppercase characters of the Letter category and '_' can appear in UPPER_SNAKE_CASE strings: %c in at byte-offset %d does not comply", s, char, z)
 		}
 	}
 	// flush one last time to get the remainder of the string
@@ -270,7 +273,7 @@ func DecodeCasePreservingSnakeCase(s string) (DecodedIdentifier, error) {
 	// ignore the size of the rune
 	r, _ := utf8.DecodeRuneInString(s)
 	if r == utf8.RuneError || unicode.IsDigit(r) {
-		return nil, fmt.Errorf("Converting case of %q: Case_Preserving_Snake_Case strings can't start with characters of the Decimal Digit category", s)
+		return nil, fmt.Errorf("converting case of %q: Case_Preserving_Snake_Case strings can't start with characters of the Decimal Digit category", s)
 
 	}
 	words := []string{}
@@ -284,7 +287,7 @@ func DecodeCasePreservingSnakeCase(s string) (DecodedIdentifier, error) {
 			}
 			lastBoundary = z + 1
 		} else if !unicode.IsLetter(char) && !unicode.IsDigit(char) {
-			return nil, fmt.Errorf("Converting case of %q: Only characters of the Letter category and '_' can appear in Preserving_Snake_Case strings: %c at byte-offset %d does not comply", s, char, z)
+			return nil, fmt.Errorf("converting case of %q: Only characters of the Letter category and '_' can appear in Preserving_Snake_Case strings: %c at byte-offset %d does not comply", s, char, z)
 		}
 	}
 	words = append(words, strings.ToLower(s[lastBoundary:]))
@@ -304,7 +307,7 @@ func EncodeUpperCamelCase(words DecodedIdentifier) string {
 	b := strings.Builder{}
 	b.Grow(aggregateStringLen(words))
 	for _, w := range words {
-		b.WriteString(strings.Title(w))
+		b.WriteString(cases.Title(language.English, cases.NoLower).String(w))
 	}
 	return b.String()
 }
@@ -318,7 +321,7 @@ func EncodeLowerCamelCase(words DecodedIdentifier) string {
 	b.Grow(aggregateStringLen(words))
 	b.WriteString(words[0])
 	for _, w := range words[1:] {
-		b.WriteString(strings.Title(w))
+		b.WriteString(cases.Title(language.English, cases.NoLower).String(w))
 	}
 	return b.String()
 }

--- a/transform/flatten_mangler.go
+++ b/transform/flatten_mangler.go
@@ -53,7 +53,7 @@ func (f *FlattenMangler) Mangle(sf reflect.StructField) ([]reflect.StructField, 
 	switch sf.Type.Kind() {
 	case reflect.Ptr, reflect.Map, reflect.Slice, reflect.Interface:
 	default:
-		return []reflect.StructField{}, fmt.Errorf("FlattenMangler: programmer error: expected pointerized fields, got %s",
+		return []reflect.StructField{}, fmt.Errorf("flattenMangler: programmer error: expected pointerized fields, got %s",
 			sf.Type)
 	}
 
@@ -174,7 +174,7 @@ func (f *FlattenMangler) getTag(sf *reflect.StructField, tags, flattenedPath []s
 		// decode the field name assuming it's camel case before appending it
 		decodedField, err := caseconversion.DecodeGoCamelCase(sf.Name)
 		if err != nil {
-			return sf.Tag, nil, fmt.Errorf("Error decoding field name %s: %w", sf.Name, err)
+			return sf.Tag, nil, fmt.Errorf("error decoding field name %s: %w", sf.Name, err)
 		}
 		tags = append(tags[:len(tags):len(tags)], decodedField...)
 
@@ -212,7 +212,7 @@ func (f *FlattenMangler) Unmangle(sf reflect.StructField, vs []FieldValueTuple) 
 	}
 
 	if output != len(vs) {
-		return val, fmt.Errorf("Error unmangling %v. Number of input values %d not equal to number of struct fields that need values %d", sf, len(vs), output)
+		return val, fmt.Errorf("error unmangling %v. Number of input values %d not equal to number of struct fields that need values %d", sf, len(vs), output)
 	}
 
 	return val, nil
@@ -221,7 +221,7 @@ func (f *FlattenMangler) Unmangle(sf reflect.StructField, vs []FieldValueTuple) 
 // populateStruct populates the original value with values from the flattend values
 func populateStruct(originalVal reflect.Value, vs []FieldValueTuple, inputIndex int) (int, error) {
 	if !originalVal.CanSet() {
-		return inputIndex, fmt.Errorf("Error unmangling %s. Need addressable type, actual %q", originalVal, originalVal.Type().Kind())
+		return inputIndex, fmt.Errorf("error unmangling %s. Need addressable type, actual %q", originalVal, originalVal.Type().Kind())
 	}
 
 	kind, vt := getUnderlyingKindType(originalVal.Type())
@@ -259,11 +259,11 @@ func populateStruct(originalVal reflect.Value, vs []FieldValueTuple, inputIndex 
 			default:
 			}
 			if !nestedVal.CanSet() {
-				return inputIndex, fmt.Errorf("Nested value %s under %s cannot be set", nestedVal, originalVal)
+				return inputIndex, fmt.Errorf("nested value %s under %s cannot be set", nestedVal, originalVal)
 			}
 
 			if !vs[inputIndex].Value.Type().AssignableTo(nestedVal.Type()) {
-				return inputIndex, fmt.Errorf("Error unmangling. Expected type %s. Actual type %s", vs[inputIndex].Value.Type(), nestedVal.Type())
+				return inputIndex, fmt.Errorf("error unmangling. Expected type %s. Actual type %s", vs[inputIndex].Value.Type(), nestedVal.Type())
 			}
 			nestedVal.Set(vs[inputIndex].Value)
 			inputIndex++

--- a/transform/string_casting_mangler_test.go
+++ b/transform/string_casting_mangler_test.go
@@ -306,7 +306,7 @@ func TestStringCastingManglerUnmangle(t *testing.T) {
 		"invalid_map": {
 			StructFieldType: reflect.TypeOf(map[string][]int{}),
 			StringValue:     `"asdf": 1, "asdf": 2, "zxcv": 3`,
-			ExpectedErr:     "Unsupported map type",
+			ExpectedErr:     "unsupported map type",
 		},
 		"string_set": {
 			StructFieldType: reflect.TypeOf(map[string]struct{}{}),


### PR DESCRIPTION
Clean up all the staticcheck warnings:

```
$ staticcheck ./...
parse/number.go:33:48: error strings should not be capitalized (ST1005)
parse/number.go:62:48: error strings should not be capitalized (ST1005)
parse/number.go:91:48: error strings should not be capitalized (ST1005)
parse/number.go:105:48: error strings should not be capitalized (ST1005)
parse/number.go:118:48: error strings should not be capitalized (ST1005)
parse/number.go:131:48: error strings should not be capitalized (ST1005)
parse/parse_string.go:10:2: var stringSliceType is unused (U1000)
parse/parse_string.go:11:2: var boolSliceType is unused (U1000)
parse/parse_string.go:12:2: var intSliceType is unused (U1000)
parse/parse_string.go:13:2: var int8SliceType is unused (U1000)
parse/parse_string.go:14:2: var int16SliceType is unused (U1000)
parse/parse_string.go:15:2: var int32SliceType is unused (U1000)
parse/parse_string.go:16:2: var int64SliceType is unused (U1000)
parse/parse_string.go:17:2: var uintSliceType is unused (U1000)
parse/parse_string.go:18:2: var uint8SliceType is unused (U1000)
parse/parse_string.go:19:2: var uint16SliceType is unused (U1000)
parse/parse_string.go:20:2: var uint32SliceType is unused (U1000)
parse/parse_string.go:21:2: var float32SliceType is unused (U1000)
parse/parse_string.go:22:2: var float64SliceType is unused (U1000)
parse/parse_string.go:23:2: var complex64SliceType is unused (U1000)
parse/parse_string.go:24:2: var complex128SliceType is unused (U1000)
parse/parse_string.go:82:29: error strings should not be capitalized (ST1005)
parse/parse_string.go:92:27: error strings should not be capitalized (ST1005)
parse/parse_string.go:106:11: error strings should not be capitalized (ST1005)
ptrify/ptrify_test.go:13:7: type sBool is unused (U1000)
ptrify/ptrify_test.go:15:7: type sBoolPtr is unused (U1000)
sources/env/env.go:56:10: error strings should not be capitalized (ST1005)
sources/flag/flag.go:151:9: error strings should not be capitalized (ST1005)
sources/flag/flag.go:388:10: error strings should not be capitalized (ST1005)
sources/flag/flag.go:425:3: redundant return statement (S1023)
sources/flag/flag.go:478:8: error strings should not be capitalized (ST1005)
sources/flag/flag_test.go:159:2: ineffective assignment to field tu.Text (SA4005)
sources/pflag/pflag.go:141:9: error strings should not be capitalized (ST1005)
sources/pflag/pflag.go:408:10: error strings should not be capitalized (ST1005)
sources/pflag/pflag.go:441:3: redundant return statement (S1023)
sources/pflag/pflag.go:474:8: error strings should not be capitalized (ST1005)
sources/pflag/pflag_test.go:162:2: ineffective assignment to field tu.Text (SA4005)
tagformat/caseconversion/case_conversion.go:30:15: error strings should not be capitalized (ST1005)
tagformat/caseconversion/case_conversion.go:36:16: error strings should not be capitalized (ST1005)
tagformat/caseconversion/case_conversion.go:57:15: error strings should not be capitalized (ST1005)
tagformat/caseconversion/case_conversion.go:67:15: error strings should not be capitalized (ST1005)
tagformat/caseconversion/case_conversion.go:158:15: error strings should not be capitalized (ST1005)
tagformat/caseconversion/case_conversion.go:205:15: error strings should not be capitalized (ST1005)
tagformat/caseconversion/case_conversion.go:218:16: error strings should not be capitalized (ST1005)
tagformat/caseconversion/case_conversion.go:244:15: error strings should not be capitalized (ST1005)
tagformat/caseconversion/case_conversion.go:257:16: error strings should not be capitalized (ST1005)
tagformat/caseconversion/case_conversion.go:273:15: error strings should not be capitalized (ST1005)
tagformat/caseconversion/case_conversion.go:287:16: error strings should not be capitalized (ST1005)
tagformat/caseconversion/case_conversion.go:307:17: strings.Title has been deprecated since Go 1.18 and an alternative has been available since Go 1.0: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead.  (SA1019)
tagformat/caseconversion/case_conversion.go:321:17: strings.Title has been deprecated since Go 1.18 and an alternative has been available since Go 1.0: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead.  (SA1019)
transform/flatten_mangler.go:262:24: error strings should not be capitalized (ST1005)
```