### PR TITLE
flags/pflags: skip registering flags on some types

### DIFF
--- a/sources/flag/flag.go
+++ b/sources/flag/flag.go
@@ -315,10 +315,12 @@ func (s *Set) registerFlags(tmpl reflect.Value, ptyp reflect.Type) error {
 			case stringSet:
 				s.Flags.Var(flaghelper.NewStringSetFlag(fieldVal.Addr().Interface().(*map[string]struct{})), name, help)
 			default:
-				return fmt.Errorf("unhandled type %s", ft)
+				// Unhandled type. Just keep going.
+				continue
 			}
 		default:
-			return fmt.Errorf("unhandled type %s", ft)
+			// Unhandled type. Just keep going.
+			continue
 		}
 	}
 	return nil

--- a/sources/pflag/pflag.go
+++ b/sources/pflag/pflag.go
@@ -327,11 +327,13 @@ func (s *Set) registerFlags(tmpl reflect.Value, ptyp reflect.Type) error {
 				f = fieldVal.Addr().Interface()
 				s.Flags.VarP(flaghelper.NewStringSetFlag(fieldVal.Addr().Interface().(*map[string]struct{})), name, shorthand, help)
 			default:
-				return fmt.Errorf("unhandled type %s", ft)
+				// Unhandled type. Just keep going.
+				continue
 			}
 
 		default:
-			return fmt.Errorf("unhandled type %s", ft)
+			// Unhandled type. Just keep going.
+			continue
 		}
 
 		v := reflect.ValueOf(f)


### PR DESCRIPTION
Types that are not explicitly handled currently error out, requiring a bunch of `dialsflag:"-"` spam. Fix this by continuing the loop when these are encountered.