### PR TITLE
Create SingleTypeSubstitutionMangler

### DIFF
--- a/transform/single_type_substitution_mangler.go
+++ b/transform/single_type_substitution_mangler.go
@@ -1,0 +1,194 @@
+package transform
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// SingleTypeSubstitutionMangler implements Mangler, and converts between two types that are convertible to one another
+// Must be constructed with NewSingleTypeSubstitutionMangler to fill in the unexported reflect.Type fields.
+// The two types must be convertible (by Go's definition), so we can directly convert one value to the other.
+// The F type-argument is the "from" type, which is being being replaced.
+// The T type-argument is the "to" type, which is taking its place during processing (and swapped back to F during Unmangle).
+type SingleTypeSubstitutionMangler[F, T any] struct {
+	from, to reflect.Type
+}
+
+// NewSingleTypeSubstitutionMangler constructs a new SingleTypeSubstitutionMangler, filling in the unexported fields.
+// The F type-argument is the "from" type, which is being being replaced.
+// The T type-argument is the "to" type, which is taking its place during processing (and swapped back to F during Unmangle).
+// If T is not convertible to F, an error is returned. (only Unmangle converts
+// values back, so convertibility in the other direction is irrelevant)
+func NewSingleTypeSubstitutionMangler[F, T any]() (*SingleTypeSubstitutionMangler[F, T], error) {
+	from := reflect.TypeOf((*F)(nil)).Elem()
+	to := reflect.TypeOf((*T)(nil)).Elem()
+	if !to.ConvertibleTo(from) {
+		return nil, fmt.Errorf("type %s is not convertible to %s", to, from)
+	}
+	return &SingleTypeSubstitutionMangler[F, T]{
+		from: from,
+		to:   to,
+	}, nil
+}
+
+// Mangle is called for every field in a struct, and maps that to one or more output fields.
+// Implementations that desire to leave fields unchanged should return
+// the argument unchanged. (particularly useful if taking advantage of
+// recursive evaluation)
+func (s *SingleTypeSubstitutionMangler[F, T]) Mangle(sf reflect.StructField) ([]reflect.StructField, error) {
+	if newType, sub := s.subType(sf.Type); sub {
+		newField := sf
+		newField.Type = newType
+
+		return []reflect.StructField{newField}, nil
+	}
+	// nothing to do
+	return []reflect.StructField{sf}, nil
+}
+
+func (s *SingleTypeSubstitutionMangler[F, T]) subType(t reflect.Type) (reflect.Type, bool) {
+	if t == s.from {
+		return s.to, true
+	}
+	if t == reflect.PointerTo(s.from) {
+		return reflect.PointerTo(s.to), true
+	}
+	// With the easy cases out of the way, handle maps, arrays and slices
+	switch t.Kind() {
+	case reflect.Pointer:
+		nElem, subPtr := s.subType(t.Elem())
+		if !subPtr {
+			return t, false
+		}
+		return reflect.PointerTo(nElem), true
+	case reflect.Map:
+		nkType, subKey := s.subType(t.Key())
+		nvType, subVal := s.subType(t.Elem())
+		if !subKey && !subVal {
+			return t, false
+		}
+		return reflect.MapOf(nkType, nvType), true
+	case reflect.Array:
+		nElem, subArray := s.subType(t.Elem())
+		if !subArray {
+			return t, false
+		}
+		return reflect.ArrayOf(t.Len(), nElem), true
+	case reflect.Slice:
+		nElem, subSlice := s.subType(t.Elem())
+		if !subSlice {
+			return t, false
+		}
+		return reflect.SliceOf(nElem), true
+	case reflect.Chan:
+		nElem, subChan := s.subType(t.Elem())
+		if !subChan {
+			return t, false
+		}
+		return reflect.ChanOf(t.ChanDir(), nElem), true
+	default:
+		// All other types are handled by the Transformer recursing
+		return t, false
+	}
+}
+
+// Unmangle is called for every source-field->mangled-field
+// mapping-set, with the mangled-field and its populated value set. The
+// implementation of Unmangle should return a reflect.Value that will
+// be used for the next mangler or final struct value)
+// Returned reflect.Value should be convertible to the field's type.
+func (s *SingleTypeSubstitutionMangler[F, T]) Unmangle(sf reflect.StructField, fval []FieldValueTuple) (reflect.Value, error) {
+	// fortunately, we never drop fields, or split fields out, so this is easy :)
+	out, _ := s.subVal(sf.Type, fval[0].Value)
+	return out, nil
+}
+
+func (s *SingleTypeSubstitutionMangler[F, T]) subVal(t reflect.Type, mVal reflect.Value) (reflect.Value, bool) {
+	if t == s.from {
+		return mVal.Convert(s.from), true
+	}
+	if t == reflect.PointerTo(s.from) {
+		// it'll be a pointer
+		if mVal.IsNil() {
+			return reflect.Zero(t), true
+		}
+		outVal := mVal.Elem().Convert(s.from)
+		outPtr := reflect.New(s.from)
+		outPtr.Elem().Set(outVal)
+		return outPtr, true
+	}
+	// With the easy cases out of the way, handle maps, arrays and slices
+	// first check for nil pointers/maps/slices/channels, though
+	if isNil(mVal) {
+		// Return a nil of the right type.
+		// There's nothing to do.
+		return reflect.Zero(t), true
+	}
+	// skip the rest if subType wouldn't substitute anything
+	_, subArray := s.subType(t)
+	if !subArray {
+		return mVal, false
+	}
+	switch t.Kind() {
+	case reflect.Pointer:
+		nElem, subPtr := s.subVal(t.Elem(), mVal.Elem())
+		if !subPtr {
+			return mVal, false
+		}
+		return nElem.Addr(), true
+	case reflect.Map:
+		// we mangled the map type, and the map value we're converting back is non-nil
+		out := reflect.MakeMapWithSize(t, mVal.Len())
+		mIter := mVal.MapRange()
+		for mIter.Next() {
+			k, _ := s.subVal(t.Key(), mIter.Key())
+			v, _ := s.subVal(t.Elem(), mIter.Value())
+			out.SetMapIndex(k, v)
+		}
+		return out, true
+	case reflect.Array:
+		out := reflect.New(t).Elem()
+		for i := 0; i < mVal.Len(); i++ {
+			slot := mVal.Index(i)
+			nVal, _ := s.subVal(t.Elem(), slot)
+			out.Index(i).Set(nVal)
+		}
+		return out, true
+	case reflect.Slice:
+		out := reflect.MakeSlice(t, mVal.Len(), mVal.Cap())
+		for i := 0; i < mVal.Len(); i++ {
+			slot := mVal.Index(i)
+			nVal, _ := s.subVal(t.Elem(), slot)
+			out.Index(i).Set(nVal)
+		}
+		return out, true
+	case reflect.Chan:
+		directionlessT := reflect.ChanOf(reflect.BothDir, t.Elem())
+		out := reflect.MakeChan(directionlessT, mVal.Cap())
+		if mVal.Cap() == 0 {
+			return out, true
+		}
+		// Since we constructed these two channels to have the same
+		// capacity, and there shouldn't be a way for anything else to
+		// be sending on this channel, we can copy any values into the final one.
+		for {
+			_, recvVal, _ := reflect.Select([]reflect.SelectCase{{Dir: reflect.SelectRecv, Chan: mVal}, {Dir: reflect.SelectDefault}})
+			if !recvVal.IsValid() {
+				// break out of the loop when we empty the channel
+				break
+			}
+			nVal, _ := s.subVal(out.Type().Elem(), recvVal)
+			out.Send(nVal) // this shouldn't block unless some blockhead is still sending on the channel
+		}
+		return out, true
+	default:
+		// All other types are handled by the Transformer recursing
+		return mVal, false
+	}
+}
+
+// ShouldRecurse is called after Mangle for each field so nested struct
+// fields get iterated over after any transformation done by Mangle().
+func (s *SingleTypeSubstitutionMangler[F, T]) ShouldRecurse(reflect.StructField) bool {
+	return true
+}

--- a/transform/single_type_substitution_mangler_test.go
+++ b/transform/single_type_substitution_mangler_test.go
@@ -1,0 +1,355 @@
+package transform
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+type checkFieldTypeAndSetValsFieldDesc struct {
+	fieldName string
+	expType   reflect.Type
+	setVal    any
+}
+
+func checkFieldTypeAndSetVals(t testing.TB, val reflect.Value, fDescs []checkFieldTypeAndSetValsFieldDesc) {
+	t.Helper()
+
+	for _, fDesc := range fDescs {
+		f := val.FieldByName(fDesc.fieldName)
+		if f.Type() != fDesc.expType {
+			t.Errorf("unexpected type for field %q: %s; expected %s", fDesc.fieldName, f.Type(), fDesc.expType)
+			continue
+		}
+		setV := reflect.ValueOf(fDesc.setVal)
+		f.Set(setV)
+	}
+}
+
+func TestSingleTypeSubstitutionMangler_Int64_Int8(t *testing.T) {
+	t.Parallel()
+	type testStruct struct {
+		Foo          int64
+		Bar          int64
+		Boop         [3]int64
+		Baz          *int64
+		BarChan      <-chan int64
+		BarChanUnbuf <-chan int64
+		BazChan      <-chan *int64
+		BazChanUnbuf <-chan *int64
+		Fizzle       string
+		Fooble       *string
+	}
+
+	m, constrErr := NewSingleTypeSubstitutionMangler[int64, int8]()
+	if constrErr != nil {
+		t.Fatalf("failed to construct substitution mangler: %s", constrErr)
+	}
+
+	itype := reflect.TypeOf(testStruct{})
+
+	tfmr := NewTransformer(itype, m)
+	val, trErr := tfmr.Translate()
+	if trErr != nil {
+		t.Fatalf("failed to translate type: %s", trErr)
+	}
+	int8T := reflect.TypeOf(int8(8))
+	strT := reflect.TypeOf("")
+
+	bazChanVal := int8(31)
+	checkFieldTypeAndSetVals(t, val, []checkFieldTypeAndSetValsFieldDesc{
+		{fieldName: "Foo", expType: int8T, setVal: int8(8)},
+		{fieldName: "Bar", expType: int8T, setVal: int8(33)},
+		{fieldName: "Boop", expType: reflect.ArrayOf(3, int8T), setVal: [3]int8{33, 123, 9}},
+		{fieldName: "Baz", expType: reflect.PointerTo(int8T), setVal: func() *int8 { v := int8(38); return &v }()},
+		{fieldName: "BarChan", expType: reflect.ChanOf(reflect.RecvDir, int8T), setVal: func() chan int8 { v := make(chan int8, 3); v <- 22; return v }()},
+		{fieldName: "BarChanUnbuf", expType: reflect.ChanOf(reflect.RecvDir, int8T), setVal: make(chan int8)},
+		{fieldName: "BazChan", expType: reflect.ChanOf(reflect.RecvDir, reflect.PointerTo(int8T)), setVal: func() chan *int8 { v := make(chan *int8, 3); v <- &bazChanVal; return v }()},
+		{fieldName: "BazChanUnbuf", expType: reflect.ChanOf(reflect.RecvDir, reflect.PointerTo(int8T)), setVal: make(chan *int8)},
+		{fieldName: "Fizzle", expType: strT, setVal: "foobar"},
+		{fieldName: "Fooble", expType: reflect.PointerTo(strT), setVal: func() *string { v := "feebleboop"; return &v }()},
+	})
+
+	revVal, revTrErr := tfmr.ReverseTranslate(val)
+	if revTrErr != nil {
+		t.Fatalf("failed to reverse translate type: %s", revTrErr)
+	}
+
+	expBazVal := int64(38)
+	expFooble := "feebleboop"
+
+	rv := revVal.Interface().(testStruct)
+	if expOut := (testStruct{
+		Foo:          8,
+		Bar:          33,
+		Baz:          &expBazVal,
+		Boop:         [3]int64{33, 123, 9},
+		BarChan:      rv.BarChan,
+		BarChanUnbuf: rv.BarChanUnbuf,
+		BazChan:      rv.BazChan,
+		BazChanUnbuf: rv.BazChanUnbuf,
+		Fizzle:       "foobar",
+		Fooble:       &expFooble,
+	}); !reflect.DeepEqual(revVal.Interface(), expOut) {
+		t.Errorf("unexpected output:\n got %+v\nwant %+v", revVal.Interface(), expOut)
+	}
+	if len(rv.BarChan) != 1 {
+		t.Errorf("BarChan has unexpected number of values: %d; expected 1", len(rv.BarChan))
+	}
+	if cap(rv.BarChan) != 3 {
+		t.Errorf("BarChan has unexpected capacity: %d; expected 3", cap(rv.BarChan))
+	}
+	select {
+	case v := <-rv.BarChan:
+		if v != 22 {
+			t.Errorf("unexpected value for value in BarChan: %d; expected 22", v)
+		}
+	default:
+		t.Errorf("BarChan empty")
+	}
+	if len(rv.BazChan) != 1 {
+		t.Errorf("BazChan has unexpected number of values: %d; expected 1", len(rv.BazChan))
+	}
+	if cap(rv.BazChan) != 3 {
+		t.Errorf("BazChan has unexpected capacity: %d; expected 3", cap(rv.BazChan))
+	}
+	select {
+	case v := <-rv.BazChan:
+		if v == nil {
+			t.Errorf("unexpected nil value for value in BazChan; expected pointer to 31")
+		} else if *v != 31 {
+			t.Errorf("unexpected value for value in BazChan: %d; expected pointer to 31", *v)
+		}
+	default:
+		t.Errorf("BazChan empty")
+	}
+}
+
+func TestSingleTypeSubstitutionMangler_timeDuration_int64(t *testing.T) {
+	t.Parallel()
+	type testStruct struct {
+		Foo         time.Duration
+		Bar         time.Duration
+		Baz         *time.Duration
+		BarChanNone chan time.Duration
+		BazChanNone chan *time.Duration
+		Fizzle      string
+		Fooble      *string
+	}
+
+	m, constrErr := NewSingleTypeSubstitutionMangler[time.Duration, int64]()
+	if constrErr != nil {
+		t.Fatalf("failed to construct substitution mangler: %s", constrErr)
+	}
+
+	itype := reflect.TypeOf(testStruct{})
+
+	tfmr := NewTransformer(itype, m)
+	val, trErr := tfmr.Translate()
+	if trErr != nil {
+		t.Fatalf("failed to translate type: %s", trErr)
+	}
+	int64T := reflect.TypeOf(int64(8))
+	strT := reflect.TypeOf("")
+
+	checkFieldTypeAndSetVals(t, val, []checkFieldTypeAndSetValsFieldDesc{
+		{fieldName: "Foo", expType: int64T, setVal: int64(8_000_023)},
+		{fieldName: "Bar", expType: int64T, setVal: int64(33_000_081)},
+		{fieldName: "Baz", expType: reflect.PointerTo(int64T), setVal: func() *int64 { v := int64(393455); return &v }()},
+		{fieldName: "BarChanNone", expType: reflect.ChanOf(reflect.BothDir, int64T), setVal: (chan int64)(nil)},
+		{fieldName: "BazChanNone", expType: reflect.ChanOf(reflect.BothDir, reflect.PointerTo(int64T)), setVal: (chan *int64)(nil)},
+		{fieldName: "Fizzle", expType: strT, setVal: "foobar"},
+		{fieldName: "Fooble", expType: reflect.PointerTo(strT), setVal: func() *string { v := "feebleboop"; return &v }()},
+	})
+
+	revVal, revTrErr := tfmr.ReverseTranslate(val)
+	if revTrErr != nil {
+		t.Fatalf("failed to reverse translate type: %s", revTrErr)
+	}
+
+	expBazVal := 393455 * time.Nanosecond
+	expFooble := "feebleboop"
+
+	if expOut := (testStruct{
+		Foo:         8_000_023 * time.Nanosecond,
+		Bar:         33_000_081 * time.Nanosecond,
+		Baz:         &expBazVal,
+		BarChanNone: nil,
+		BazChanNone: nil,
+		Fizzle:      "foobar",
+		Fooble:      &expFooble,
+	}); !reflect.DeepEqual(revVal.Interface(), expOut) {
+		t.Errorf("unexpected output: got %+v; want %+v", revVal.Interface(), expOut)
+	}
+}
+
+func TestSingleTypeSubstitutionMangler_Int64_Int16_map_slice_fields(t *testing.T) {
+	t.Parallel()
+	type testStruct struct {
+		Foo           map[string]int64
+		Bar           []int64
+		Baz           *int64
+		Bamboozle     map[int64]int64
+		BamboozleNone map[int64]int64
+		BarNone       []int64
+		BazNone       *int64
+		Fizzle        string
+		Fooble        *string
+		Fromble       *string
+	}
+
+	m, constrErr := NewSingleTypeSubstitutionMangler[int64, int16]()
+	if constrErr != nil {
+		t.Fatalf("failed to construct substitution mangler: %s", constrErr)
+	}
+
+	itype := reflect.TypeOf(testStruct{})
+
+	tfmr := NewTransformer(itype, m)
+	val, trErr := tfmr.Translate()
+	if trErr != nil {
+		t.Fatalf("failed to translate type: %s", trErr)
+	}
+	int16T := reflect.TypeOf(int16(8))
+	strT := reflect.TypeOf("")
+
+	checkFieldTypeAndSetVals(t, val, []checkFieldTypeAndSetValsFieldDesc{
+		{fieldName: "Foo", expType: reflect.MapOf(strT, int16T), setVal: map[string]int16{"abc": 8}},
+		{fieldName: "Bar", expType: reflect.SliceOf(int16T), setVal: []int16{33, 1337}},
+		{fieldName: "BarNone", expType: reflect.SliceOf(int16T), setVal: []int16(nil)},
+		{fieldName: "Bamboozle", expType: reflect.MapOf(int16T, int16T), setVal: map[int16]int16{1997: 9}},
+		{fieldName: "BamboozleNone", expType: reflect.MapOf(int16T, int16T), setVal: map[int16]int16(nil)},
+		{fieldName: "Baz", expType: reflect.PointerTo(int16T), setVal: func() *int16 { v := int16(38); return &v }()},
+		{fieldName: "BazNone", expType: reflect.PointerTo(int16T), setVal: (*int16)(nil)},
+		{fieldName: "Fizzle", expType: strT, setVal: "foobar"},
+		{fieldName: "Fooble", expType: reflect.PointerTo(strT), setVal: func() *string { v := "feebleboop"; return &v }()},
+		{fieldName: "Fromble", expType: reflect.PointerTo(strT), setVal: (*string)(nil)},
+	})
+
+	revVal, revTrErr := tfmr.ReverseTranslate(val)
+	if revTrErr != nil {
+		t.Fatalf("failed to reverse translate type: %s", revTrErr)
+	}
+
+	expBazVal := int64(38)
+	expFooble := "feebleboop"
+
+	if expOut := (testStruct{
+		Foo:           map[string]int64{"abc": 8},
+		Bar:           []int64{33, 1337},
+		Baz:           &expBazVal,
+		Bamboozle:     map[int64]int64{1997: 9},
+		BarNone:       nil,
+		BazNone:       nil,
+		BamboozleNone: nil,
+		Fizzle:        "foobar",
+		Fooble:        &expFooble,
+		Fromble:       nil,
+	}); !reflect.DeepEqual(revVal.Interface(), expOut) {
+		t.Errorf("unexpected output: got %+v; want %+v", revVal.Interface(), expOut)
+	}
+}
+
+func TestSingleTypeSubstitutionMangler_Int64_Int16_nested_fields(t *testing.T) {
+	t.Parallel()
+	type innerStruct struct {
+		Foo           map[string]int64
+		Bar           []int64
+		Baz           *int64
+		Bamboozle     map[int64]int64
+		BamboozleNone map[int64]int64
+	}
+	type testStruct struct {
+		P       *innerStruct
+		I       innerStruct
+		PNone   *innerStruct
+		BarNone []int64
+		BazNone *int64
+		Fizzle  string
+		Fooble  *string
+		Fromble *string
+	}
+
+	m, constrErr := NewSingleTypeSubstitutionMangler[int64, int16]()
+	if constrErr != nil {
+		t.Fatalf("failed to construct substitution mangler: %s", constrErr)
+	}
+
+	itype := reflect.TypeOf(testStruct{})
+
+	tfmr := NewTransformer(itype, m)
+	val, trErr := tfmr.Translate()
+	if trErr != nil {
+		t.Fatalf("failed to translate type: %s", trErr)
+	}
+	int16T := reflect.TypeOf(int16(8))
+	strT := reflect.TypeOf("")
+
+	iVal := val.FieldByName("I")
+	checkFieldTypeAndSetVals(t, iVal, []checkFieldTypeAndSetValsFieldDesc{
+		{fieldName: "Foo", expType: reflect.MapOf(strT, int16T), setVal: map[string]int16{"abc": 8}},
+		{fieldName: "Bar", expType: reflect.SliceOf(int16T), setVal: []int16{33, 1337}},
+		{fieldName: "Baz", expType: reflect.PointerTo(int16T), setVal: func() *int16 { v := int16(38); return &v }()},
+		{fieldName: "Bamboozle", expType: reflect.MapOf(int16T, int16T), setVal: map[int16]int16{1997: 9}},
+		{fieldName: "BamboozleNone", expType: reflect.MapOf(int16T, int16T), setVal: map[int16]int16(nil)},
+	})
+	pField := val.FieldByName("P")
+	pPtr := reflect.New(pField.Type().Elem())
+	pVal := pPtr.Elem()
+	pField.Set(pPtr)
+	checkFieldTypeAndSetVals(t, pVal, []checkFieldTypeAndSetValsFieldDesc{
+		{fieldName: "Foo", expType: reflect.MapOf(strT, int16T), setVal: map[string]int16{"abc": 31_123}},
+		{fieldName: "Bar", expType: reflect.SliceOf(int16T), setVal: []int16{37, 1339}},
+		{fieldName: "Baz", expType: reflect.PointerTo(int16T), setVal: func() *int16 { v := int16(36); return &v }()},
+		{fieldName: "Bamboozle", expType: reflect.MapOf(int16T, int16T), setVal: map[int16]int16{1987: 10}},
+		{fieldName: "BamboozleNone", expType: reflect.MapOf(int16T, int16T), setVal: map[int16]int16(nil)},
+	})
+
+	checkFieldTypeAndSetVals(t, val, []checkFieldTypeAndSetValsFieldDesc{
+		{fieldName: "BarNone", expType: reflect.SliceOf(int16T), setVal: []int16(nil)},
+		{fieldName: "BazNone", expType: reflect.PointerTo(int16T), setVal: (*int16)(nil)},
+		{fieldName: "Fizzle", expType: strT, setVal: "foobar"},
+		{fieldName: "Fooble", expType: reflect.PointerTo(strT), setVal: func() *string { v := "feebleboop"; return &v }()},
+		{fieldName: "Fromble", expType: reflect.PointerTo(strT), setVal: (*string)(nil)},
+		{fieldName: "PNone", expType: reflect.PointerTo(iVal.Type()), setVal: reflect.Zero(reflect.PointerTo(iVal.Type())).Interface()},
+	})
+
+	revVal, revTrErr := tfmr.ReverseTranslate(val)
+	if revTrErr != nil {
+		t.Fatalf("failed to reverse translate type: %s", revTrErr)
+	}
+
+	expBazVal := int64(38)
+	expPtrBazVal := int64(36)
+	expFooble := "feebleboop"
+
+	rv := revVal.Interface().(testStruct)
+
+	if expOut := (testStruct{
+		I: innerStruct{
+			Foo:           map[string]int64{"abc": 8},
+			Bar:           []int64{33, 1337},
+			Baz:           &expBazVal,
+			Bamboozle:     map[int64]int64{1997: 9},
+			BamboozleNone: nil,
+		},
+		P: &innerStruct{
+			Foo:           map[string]int64{"abc": 31_123},
+			Bar:           []int64{37, 1339},
+			Baz:           &expPtrBazVal,
+			Bamboozle:     map[int64]int64{1987: 10},
+			BamboozleNone: nil,
+		},
+		PNone:   nil,
+		BarNone: nil,
+		BazNone: nil,
+		Fizzle:  "foobar",
+		Fooble:  &expFooble,
+		Fromble: nil,
+	}); !reflect.DeepEqual(rv, expOut) {
+		t.Errorf("unexpected output:\n got %+v\nwant %+v", revVal.Interface(), expOut)
+		t.Logf("I:\n got %+v\nwant %+v", rv.I, expOut.I)
+		t.Logf("P:\n got %+v\nwant %+v", *rv.P, *expOut.P)
+		t.Logf("P.Baz:\n got %v\nwant %v", *rv.P.Baz, *expOut.P.Baz)
+	}
+}


### PR DESCRIPTION
Implement a Mangler implementation that takes two type-arguments that are directly convertible to convert to and from.

This will facilitate point-substituting time.Duration with a type that's also an int64, but has an `UnmarshalJSON` method that calls `time.ParseDuration` if it's passed a JSON string, and parses an integer as nanoseconds if passed a JSON integer/number. -- for use by the json and cue decoders.