### PR TITLE
json/cue: substitute time.Duration with type using time.ParseDuration

### DIFF
--- a/decoders/json/json.go
+++ b/decoders/json/json.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"time"
 
 	"github.com/vimeo/dials"
 	"github.com/vimeo/dials/common"
+	"github.com/vimeo/dials/decoders/json/jsontypes"
 	"github.com/vimeo/dials/tagformat"
 	"github.com/vimeo/dials/transform"
 )
@@ -17,6 +19,18 @@ const JSONTagName = "json"
 
 // Decoder is a decoder that knows how to work with text encoded in JSON
 type Decoder struct{}
+
+func must[T any](v T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// pre-declare the time.Duration -> jsontypes.ParsingDuration mangler at
+// package-scope, so we don't have to construct a new one every time Decode is
+// called.
+var parsingDurMangler = must(transform.NewSingleTypeSubstitutionMangler[time.Duration, jsontypes.ParsingDuration]())
 
 // Decode is a decoder that decodes the JSON from an io.Reader into the
 // appropriate struct.
@@ -28,6 +42,7 @@ func (d *Decoder) Decode(r io.Reader, t *dials.Type) (reflect.Value, error) {
 
 	// If there aren't any json tags, copy over from any dials tags.
 	tfmr := transform.NewTransformer(t.Type(),
+		parsingDurMangler,
 		&tagformat.TagCopyingMangler{
 			SrcTag: common.DialsTagName, NewTag: JSONTagName})
 	val, tfmErr := tfmr.Translate()

--- a/decoders/json/json.go
+++ b/decoders/json/json.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"reflect"
 
 	"github.com/vimeo/dials"
@@ -17,13 +16,12 @@ import (
 const JSONTagName = "json"
 
 // Decoder is a decoder that knows how to work with text encoded in JSON
-type Decoder struct {
-}
+type Decoder struct{}
 
 // Decode is a decoder that decodes the JSON from an io.Reader into the
 // appropriate struct.
 func (d *Decoder) Decode(r io.Reader, t *dials.Type) (reflect.Value, error) {
-	jsonBytes, err := ioutil.ReadAll(r)
+	jsonBytes, err := io.ReadAll(r)
 	if err != nil {
 		return reflect.Value{}, fmt.Errorf("error reading JSON: %s", err)
 	}

--- a/decoders/json/json_test.go
+++ b/decoders/json/json_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/vimeo/dials"
 	"github.com/vimeo/dials/sources/static"
 )
@@ -81,8 +83,9 @@ func TestDeeplyNestedJSON(t *testing.T) {
 			Username   string `dials:"username"`
 			Password   string `dials:"password"`
 			OtherStuff struct {
-				Something string `dials:"something"`
-				IPAddress net.IP `dials:"ip_address"`
+				Something   string        `dials:"something"`
+				IPAddress   net.IP        `dials:"ip_address"`
+				SomeTimeout time.Duration `dials:"some_timeout"`
 			} `dials:"other_stuff"`
 		} `dials:"database_user"`
 	}
@@ -95,7 +98,8 @@ func TestDeeplyNestedJSON(t *testing.T) {
 			"password": "password",
 			"other_stuff": {
 				"something": "asdf",
-				"ip_address": "123.10.11.121"
+				"ip_address": "123.10.11.121",
+				"some_timeout": "13s"
 			}
 		}
 	}`
@@ -114,6 +118,7 @@ func TestDeeplyNestedJSON(t *testing.T) {
 	assert.Equal(t, "test", c.DatabaseUser.Username)
 	assert.Equal(t, "password", c.DatabaseUser.Password)
 	assert.Equal(t, "asdf", c.DatabaseUser.OtherStuff.Something)
+	assert.Equal(t, time.Second*13, c.DatabaseUser.OtherStuff.SomeTimeout)
 	assert.Equal(t, net.IPv4(123, 10, 11, 121), c.DatabaseUser.OtherStuff.IPAddress)
 
 }

--- a/decoders/json/jsontypes/jsonduration.go
+++ b/decoders/json/jsontypes/jsonduration.go
@@ -1,0 +1,42 @@
+// Package jsontypes contains helper types used by the JSON and Cue decoders to
+// facilitate more natural decoding.
+package jsontypes
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// ParsingDuration implements [encoding/json.Unmarshaler], supporting both
+// quoted strings that are parseable with [time.ParseDuration], and integer nanoseconds if it's a number
+type ParsingDuration int64
+
+// UnmarshalJSON implements [encoding/json.Unmarshaler] for ParsingDuration.
+func (p *ParsingDuration) UnmarshalJSON(b []byte) error {
+	d := json.NewDecoder(bytes.NewReader(b))
+	d.UseNumber()
+	n, tokErr := d.Token()
+	if tokErr != nil {
+		return fmt.Errorf("failed to parse token: %w", tokErr)
+	}
+	switch v := n.(type) {
+	case string:
+		dur, durParseErr := time.ParseDuration(v)
+		if durParseErr != nil {
+			return fmt.Errorf("failed to parse %q as duration: %w", v, durParseErr)
+		}
+		*p = ParsingDuration(dur)
+		return nil
+	case json.Number:
+		i, intParseErr := v.Int64()
+		if intParseErr != nil {
+			return fmt.Errorf("failed to parse number as integer nanoseconds: %w", intParseErr)
+		}
+		*p = ParsingDuration(i)
+		return nil
+	default:
+		return fmt.Errorf("unexpected JSON token-type %T; expected string or number", n)
+	}
+}

--- a/decoders/json/jsontypes/jsonduration_test.go
+++ b/decoders/json/jsontypes/jsonduration_test.go
@@ -1,0 +1,88 @@
+package jsontypes
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func ptrVal[V any](v V) *V {
+	return &v
+}
+
+func TestParsingDuration(t *testing.T) {
+	t.Parallel()
+	type decStruct struct {
+		Dur    ParsingDuration
+		DurPtr *ParsingDuration
+	}
+	for _, tbl := range []struct {
+		name      string
+		inJSON    string
+		expStruct any
+		expErr    bool
+	}{
+		{
+			name:      "integer_value_no_ptr",
+			inJSON:    `{"dur": 1234}`,
+			expStruct: decStruct{Dur: 1234},
+			expErr:    false,
+		},
+		{
+			name:      "string_value_no_ptr",
+			inJSON:    `{"dur": "3s"}`,
+			expStruct: decStruct{Dur: ParsingDuration(3 * time.Second)},
+			expErr:    false,
+		},
+		{
+			name:      "string_value_ptr",
+			inJSON:    `{"dur": "3s", "durptr": "9m"}`,
+			expStruct: decStruct{Dur: ParsingDuration(3 * time.Second), DurPtr: ptrVal(ParsingDuration(9 * time.Minute))},
+			expErr:    false,
+		},
+		{
+			name:      "integer_value_ptr",
+			inJSON:    `{"dur": "3s", "durptr": 2048}`,
+			expStruct: decStruct{Dur: ParsingDuration(3 * time.Second), DurPtr: ptrVal(ParsingDuration(2048))},
+			expErr:    false,
+		},
+		{
+			name:   "error_array_val",
+			inJSON: `{"dur": [], "durptr": 2048}`,
+			expErr: true,
+		},
+		{
+			name:   "error_object_val",
+			inJSON: `{"dur": {}, "durptr": 2048}`,
+			expErr: true,
+		},
+		{
+			name:   "error_unparsable_str_val",
+			inJSON: `{"dur": "sssssssssss", "durptr": 2048}`,
+			expErr: true,
+		},
+		{
+			name:   "error_float_fractional_val",
+			inJSON: `{"dur": 0.333333, "durptr": 2048}`,
+			expErr: true,
+		},
+	} {
+		t.Run(tbl.name, func(t *testing.T) {
+			v := decStruct{}
+			decErr := json.Unmarshal([]byte(tbl.inJSON), &v)
+			if decErr != nil {
+				if !tbl.expErr {
+					t.Errorf("unexpected error unmarshaling: %s", decErr)
+				} else {
+					t.Logf("expected error: %s", decErr)
+				}
+				return
+			}
+			if !reflect.DeepEqual(v, tbl.expStruct) {
+				t.Errorf("unexpected value\n got: %+v\nwant:%+v", tbl.expStruct, v)
+			}
+		})
+
+	}
+}


### PR DESCRIPTION
Add a `jsontypes` package with a `ParsingDuration` type that implements `json.Unmarshaler`, making it possible to use both human-friendly strings (`3s`) and integer nanoseconds (for compatibility).

Leverage the new `SingleTypeSubstitutionMangler` to make this substitution in the cue and json decoders (during decoding).