### PR TITLE
AliasMangler

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,23 @@ If you wish to watch the config file and make updates to your configuration, use
 	}
 ```
 
+### Aliased Configuration Values
+Dials supports aliases for fields where you want to change the name and support
+an orderly transition from an old name to a new name.  Just as there is a
+`dials` struct tag there is also a `dialsalias` struct tag that you can use as
+an alternate name.  Any other casing or transformation rules on the original
+tags also applies to the aliases.  Only one of the original or alias versions of
+the field may be set at any time.  Setting both results in an error.  Aliases
+are supported in the other source-specific tags like `dialsenv`, `dialsflag`,
+and `dialspflag` as well by appending "alias" to the flag name.  The `ez`
+package also wraps the appropriate file source's decoder so config files can
+also make use of aliases.
+
+Aliases are implemented using the
+[Mangler](https://github.com/vimeo/dials/blob/402b4821e3f191d96580b9933583f1651325381d/transform/transformer.go#L17-L32)
+interface.  The `env`, `flag`, and `pflag` sources support aliasing without any
+additional options.
+
 ### Flags
 When setting commandline flags using either the pflag or flag sources, additional flag-types become available for simple slices and maps.
 

--- a/common/tags.go
+++ b/common/tags.go
@@ -1,5 +1,22 @@
 // Package common provides constants that are used among different dials sources
 package common
 
-// DialsTagName is the name of the dials tag.
-const DialsTagName = "dials"
+const (
+	// DialsTagName is the name of the dials tag.
+	DialsTagName = "dials"
+
+	// DialsEnvTagName is the name of the dialsenv tag.
+	DialsEnvTagName = "dialsenv"
+
+	// DialsFlagTagName is the name of the dialsflag tag.
+	DialsFlagTagName = "dialsflag"
+
+	// DialsPFlagTagName is the name of the dialspflag tag.
+	DialsPFlagTag = "dialspflag"
+
+	// DialsFlagAliasTag is the name of the dialsflagalias tag.
+	DialsPFlagShortTag = "dialspflagshort"
+
+	// HelpTextTag is the name of the struct tag for flag descriptions
+	DialsHelpTextTag = "dialsdesc"
+)

--- a/ez/ez.go
+++ b/ez/ez.go
@@ -171,16 +171,6 @@ func ConfigFileEnvFlagDecoderFactoryParams[T any, TP ConfigWithConfigPath[T]](ct
 		flagSrc = fset
 	}
 
-	// If file-watching is not enabled, we should shutdown the monitor
-	// goroutine when exiting this function.
-	// Usually `dials.Config` is smart enough not to start a monitor when
-	// there are no `Watcher` implementations in the source-list, but the
-	// `Blank` source uses `Watcher` for its core functionality, so we need
-	// to shutdown the blank source to actually clean up resources.
-	if !params.WatchConfigFile {
-		defer blank.Done(ctx)
-	}
-
 	dp := dials.Params[T]{
 		// Set the OnNewConfig callback. It'll be suppressed by the
 		// CallGlobalCallbacksAfterVerificationEnabled until just before we return.
@@ -197,6 +187,16 @@ func ConfigFileEnvFlagDecoderFactoryParams[T any, TP ConfigWithConfigPath[T]](ct
 	d, err := dp.Config(ctx, (*T)(cfg), &blank, &env.Source{}, flagSrc)
 	if err != nil {
 		return nil, err
+	}
+
+	// If file-watching is not enabled, we should shutdown the monitor
+	// goroutine when exiting this function.
+	// Usually `dials.Config` is smart enough not to start a monitor when
+	// there are no `Watcher` implementations in the source-list, but the
+	// `Blank` source uses `Watcher` for its core functionality, so we need
+	// to shutdown the blank source to actually clean up resources.
+	if !params.WatchConfigFile {
+		defer blank.Done(ctx)
 	}
 
 	basecfg := d.View()

--- a/ez/ez.go
+++ b/ez/ez.go
@@ -219,7 +219,8 @@ func ConfigFileEnvFlagDecoderFactoryParams[T any, TP ConfigWithConfigPath[T]](ct
 		return nil, fmt.Errorf("decoderFactory provided a nil decoder for path: %s", cfgPath)
 	}
 
-	manglers := make([]transform.Mangler, 0, 2)
+	manglers := make([]transform.Mangler, 0, 3)
+	manglers = append(manglers, transform.NewAliasMangler(common.DialsTagName))
 
 	if params.FileFieldNameEncoder != nil {
 		tagDecoder := params.DialsTagNameDecoder

--- a/transform/alias_mangler.go
+++ b/transform/alias_mangler.go
@@ -1,0 +1,147 @@
+package transform
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/fatih/structtag"
+	"github.com/vimeo/dials/common"
+)
+
+const (
+	dialsAliasTagSuffix = "alias"
+	aliasFieldSuffix    = "_alias9wr876rw3" // a random string to append to the alias field to avoid collisions
+)
+
+// AliasMangler manages aliases for dials, dialsenv, dialsflag, and dialspflag
+// struct tags to make it possible to migrate from one name to another
+// conveniently.
+type AliasMangler struct {
+	tags []string
+}
+
+// NewAliasMangler creates a new AliasMangler with the provided tags.
+func NewAliasMangler(tags ...string) *AliasMangler {
+	return &AliasMangler{tags: tags}
+}
+
+// Mangle implements the Mangler interface.  If any alias tag is defined, the
+// struct field will be copied with the non-aliased tag set to the alias's
+// value.
+func (a *AliasMangler) Mangle(sf reflect.StructField) ([]reflect.StructField, error) {
+	originalVals := map[string]string{}
+	aliasVals := map[string]string{}
+
+	sfTags, parseErr := structtag.Parse(string(sf.Tag))
+	if parseErr != nil {
+		return nil, fmt.Errorf("error parsing source tags %w", parseErr)
+	}
+
+	anyAliasFound := false
+	for _, tag := range a.tags {
+		if originalVal, getErr := sfTags.Get(tag); getErr == nil {
+			originalVals[tag] = originalVal.Name
+		}
+
+		if aliasVal, getErr := sfTags.Get(tag + dialsAliasTagSuffix); getErr == nil {
+			aliasVals[tag] = aliasVal.Name
+			anyAliasFound = true
+
+			// remove the alias tag from the definition
+			sfTags.Delete(tag + dialsAliasTagSuffix)
+		}
+	}
+
+	if !anyAliasFound {
+		// we didn't find any aliases so just get out early
+		return []reflect.StructField{sf}, nil
+	}
+
+	aliasField := sf
+	aliasField.Name += aliasFieldSuffix
+
+	// now that we've copied it, reset the struct tags on the source field to
+	// not include the alias tags
+	sf.Tag = reflect.StructTag(sfTags.String())
+
+	tags, parseErr := structtag.Parse(string(aliasField.Tag))
+	if parseErr != nil {
+		return nil, fmt.Errorf("error parsing struct tags: %w", parseErr)
+	}
+
+	// keep track of the aliases we actually set so we can update the dialsdesc
+	setAliases := []string{}
+
+	for tag, aliasVal := range aliasVals {
+		// remove the alias tag so it's not left on the copied StructField
+		tags.Delete(tag + dialsAliasTagSuffix)
+
+		newDialsTag := &structtag.Tag{
+			Key:  tag,
+			Name: aliasVal,
+		}
+
+		if setErr := tags.Set(newDialsTag); setErr != nil {
+			return nil, fmt.Errorf("error setting new value for dials tag: %w", setErr)
+		}
+		setAliases = append(setAliases, tag+"="+originalVals[tag])
+	}
+
+	newDialsDesc := "base dialsdesc unset" // be pessimistic in case dialsdesc isn't set
+	if desc, getErr := tags.Get(common.DialsHelpTextTag); getErr == nil {
+		newDialsDesc = desc.Name
+	}
+
+	sort.Strings(setAliases)
+	newDesc := &structtag.Tag{
+		Key:  common.DialsHelpTextTag,
+		Name: newDialsDesc + " (alias of " + strings.Join(setAliases, " ") + ")",
+	}
+	if setErr := tags.Set(newDesc); setErr != nil {
+		return nil, fmt.Errorf("error setting amended dialsdesc for tag %w", setErr)
+	}
+
+	// set the new tags on the alias field
+	aliasField.Tag = reflect.StructTag(tags.String())
+
+	return []reflect.StructField{sf, aliasField}, nil
+}
+
+// Unmangle implements the Mangler interface and unwinds the alias copying
+// operation.  Note that if both the source and alias are both set in the
+// configuration, an error will be returned.
+func (a *AliasMangler) Unmangle(sf reflect.StructField, fvs []FieldValueTuple) (reflect.Value, error) {
+	switch len(fvs) {
+	case 1:
+		// if there's only one tuple that means there was no alias, so just
+		// return...
+		return fvs[0].Value, nil
+	case 2:
+		// two means there's an alias so we should continue on...
+	default:
+		return reflect.Value{}, fmt.Errorf("expected 1 or 2 tuples, got %d", len(fvs))
+	}
+
+	if !fvs[0].Value.IsNil() && !fvs[1].Value.IsNil() {
+		return reflect.Value{}, fmt.Errorf("both alias and original set for field %q", sf.Name)
+	}
+
+	// return the first one that isn't nil
+	for _, fv := range fvs {
+		if !fv.Value.IsNil() {
+			return fv.Value, nil
+		}
+	}
+
+	// if we made it this far, they were both nil, which is fine -- just return
+	// one of them.
+	return fvs[0].Value, nil
+}
+
+// ShouldRecurse is called after Mangle for each field so nested struct
+// fields get iterated over after any transformation done by Mangle().
+func (a AliasMangler) ShouldRecurse(_ reflect.StructField) bool {
+	return true
+}

--- a/transform/alias_mangler_test.go
+++ b/transform/alias_mangler_test.go
@@ -1,0 +1,161 @@
+package transform
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/fatih/structtag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAliasManglerMangle(t *testing.T) {
+
+	for testName, itbl := range map[string]struct {
+		tag           string
+		expectedOrig  map[string]string
+		expectedAlias map[string]string
+	}{
+		"dialsOnly": {
+			tag:           `dials:"name" dialsalias:"anothername"`,
+			expectedOrig:  map[string]string{"dials": "name"},
+			expectedAlias: map[string]string{"dials": "anothername", "dialsdesc": "base dialsdesc unset (alias of dials=name)"},
+		},
+		"withDialsDesc": {
+			tag:           `dials:"name" dialsalias:"anothername" dialsdesc:"the name for this"`,
+			expectedOrig:  map[string]string{"dials": "name", "dialsdesc": "the name for this"},
+			expectedAlias: map[string]string{"dials": "anothername", "dialsdesc": "the name for this (alias of dials=name)"},
+		},
+		"dialsDialsEnvFlagPFlag": {
+			tag:           `dials:"name" dialsflag:"flagname" dialspflag:"pflagname" dialsenv:"envname" dialsalias:"anothername" dialsflagalias:"flagalias" dialspflagalias:"pflagalias" dialsenvalias:"envalias"`,
+			expectedOrig:  map[string]string{"dials": "name", "dialsflag": "flagname", "dialspflag": "pflagname", "dialsenv": "envname"},
+			expectedAlias: map[string]string{"dials": "anothername", "dialsflag": "flagalias", "dialspflag": "pflagalias", "dialsenv": "envalias", "dialsdesc": "base dialsdesc unset (alias of dials=name dialsenv=envname dialsflag=flagname dialspflag=pflagname)"},
+		},
+		"dialsDialsEnvWithDialsDesc": {
+			tag:           `dials:"name" dialsenv:"thename" dialsalias:"anothername" dialsenvalias:"theothername, "dialsdesc:"THE description"`,
+			expectedOrig:  map[string]string{"dials": "name", "dialsenv": "thename", "dialsdesc": "THE description"},
+			expectedAlias: map[string]string{"dials": "anothername", "dialsenv": "theothername", "dialsdesc": "THE description (alias of dials=name dialsenv=thename)"},
+		},
+	} {
+		tbl := itbl
+		t.Run(testName, func(t *testing.T) {
+			sf := reflect.StructField{
+				Name: "Foo",
+				Type: reflect.TypeOf(""),
+				Tag:  reflect.StructTag(tbl.tag),
+			}
+
+			aliasMangler := NewAliasMangler("dials", "dialsenv", "dialsflag", "dialspflag")
+			fields, mangleErr := aliasMangler.Mangle(sf)
+			require.NoError(t, mangleErr)
+
+			require.Len(t, fields, 2)
+
+			originalTags, parseErr := structtag.Parse(string(fields[0].Tag))
+			require.NoError(t, parseErr)
+
+			for k, v := range tbl.expectedOrig {
+				val, err := originalTags.Get(k)
+				require.NoError(t, err, "expected tag %s to be found", k)
+				assert.Equal(t, v, val.Name)
+			}
+			assert.Equal(t, len(tbl.expectedOrig), originalTags.Len())
+
+			aliasTags, parseErr := structtag.Parse(string(fields[1].Tag))
+			require.NoError(t, parseErr)
+
+			for k, v := range tbl.expectedAlias {
+				val, err := aliasTags.Get(k)
+				require.NoError(t, err)
+				assert.Equal(t, v, val.Name)
+			}
+			assert.Equal(t, len(tbl.expectedAlias), aliasTags.Len())
+		})
+	}
+}
+
+func TestAliasManglerUnmangle(t *testing.T) {
+	sf := reflect.StructField{
+		Name: "Foo",
+		Type: reflect.TypeOf(""),
+	}
+
+	num := 42
+	var nilInt *int
+
+	aliasMangler := &AliasMangler{}
+
+	originalSet := []FieldValueTuple{
+		{
+			Field: sf,
+			Value: reflect.ValueOf(&num),
+		},
+		{
+			Field: sf,
+			Value: reflect.ValueOf(nilInt),
+		},
+	}
+
+	val, err := aliasMangler.Unmangle(sf, originalSet)
+	require.NoError(t, err)
+
+	assert.Equal(t, 42, val.Elem().Interface())
+
+	aliasSet := []FieldValueTuple{
+		{
+			Field: sf,
+			Value: reflect.ValueOf(nilInt),
+		},
+		{
+			Field: sf,
+			Value: reflect.ValueOf(&num),
+		},
+	}
+
+	val, err = aliasMangler.Unmangle(sf, aliasSet)
+	require.NoError(t, err)
+
+	assert.Equal(t, 42, val.Elem().Interface())
+
+	bothSet := []FieldValueTuple{
+		{
+			Field: sf,
+			Value: reflect.ValueOf(&num),
+		},
+		{
+			Field: sf,
+			Value: reflect.ValueOf(&num),
+		},
+	}
+
+	_, err = aliasMangler.Unmangle(sf, bothSet)
+	assert.NotNil(t, err) // there should be an error if both are set!
+
+	neitherSet := []FieldValueTuple{
+		{
+			Field: sf,
+			Value: reflect.ValueOf(nilInt),
+		},
+		{
+			Field: sf,
+			Value: reflect.ValueOf(nilInt),
+		},
+	}
+
+	val, err = aliasMangler.Unmangle(sf, neitherSet)
+	require.NoError(t, err)
+
+	assert.True(t, val.IsNil())
+
+	noAlias := []FieldValueTuple{
+		{
+			Field: sf,
+			Value: reflect.ValueOf(&num),
+		},
+	}
+
+	val, err = aliasMangler.Unmangle(sf, noAlias)
+	require.NoError(t, err)
+
+	assert.Equal(t, 42, val.Elem().Interface())
+}

--- a/transform/transformer.go
+++ b/transform/transformer.go
@@ -128,12 +128,20 @@ func (t *Transformer) maybeRecursivelyMangle(mangler Mangler, state *transformMa
 		if !mangler.ShouldRecurse(field) {
 			continue
 		}
+
 		ft := field.Type
+
+		// also don't recurse into TextUnarshaler types
+		if ft.Implements(textMReflectType) || reflect.PointerTo(ft).Implements(textMReflectType) {
+			continue
+		}
+
 		// strip any outer pointerification, slice or array
 		switch ft.Kind() {
 		case reflect.Ptr, reflect.Array, reflect.Slice:
 			ft = ft.Elem()
 		}
+
 		fieldTransformer := Transformer{
 			manglers: []Mangler{mangler},
 			mState:   nil,


### PR DESCRIPTION
AliasMangler

Add a new mangler that allows us to have aliases for dials tags to
facilitate migrating from one name to another seamlessly.  If both the
old name and the new name are set, an error will be returned because the
expectation is that you're using one or the other exclusively.

Also, fix a bug in `ez` where an error thrown by a Source may cause the
process to hang.

And, lastly, specifically exclude TextUnmarshaler implementing types
from mangling.