### PR TITLE
fix: pin GitHub Actions to SHA for supply chain security

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,13 +10,13 @@ jobs:
         goversion: ["1.24", "1.25"]
     steps:
       - name: Set up Go ${{matrix.goversion}} on ${{matrix.os}}
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{matrix.goversion}}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: gofmt
         run: |


### PR DESCRIPTION
## Summary

Pin all GitHub Actions to full commit SHAs for supply chain security.

Actions referenced by tag or branch have been resolved to their commit SHA, with the original ref preserved as an inline comment. Where a sub-action had unpinned transitive dependencies, the action was upgraded to the closest newer version where all sub-actions are fully pinned.

References to this repo's own reusable workflows / composite actions have been rewritten to relative `./` paths, which run from the current commit and are exempt from SHA-pinning enforcement.
